### PR TITLE
Add Run/Stop shortcut.

### DIFF
--- a/pv/mainwindow.cpp
+++ b/pv/mainwindow.cpp
@@ -34,6 +34,7 @@
 #include <QMessageBox>
 #include <QSettings>
 #include <QWidget>
+#include <QShortcut>
 
 #include "mainwindow.hpp"
 
@@ -370,8 +371,10 @@ void MainWindow::setup_ui()
 	run_stop_button_ = new QToolButton();
 	run_stop_button_->setAutoRaise(true);
 	run_stop_button_->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
-	run_stop_button_->setShortcut(QKeySequence(Qt::Key_Space));
 	run_stop_button_->setToolTip(tr("Start/Stop Acquisition"));
+
+	run_stop_shortcut_ = new QShortcut(QKeySequence(Qt::Key_Space), run_stop_button_, SLOT(click()));
+	run_stop_shortcut_->setAutoRepeat(false);
 
 	settings_button_ = new QToolButton();
 	settings_button_->setIcon(QIcon::fromTheme("configure",

--- a/pv/mainwindow.cpp
+++ b/pv/mainwindow.cpp
@@ -401,6 +401,11 @@ void MainWindow::setup_ui()
 	session_selector_.setCornerWidget(static_tab_widget_, Qt::TopLeftCorner);
 	session_selector_.setTabsClosable(true);
 
+	close_application_shortcut_ = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), this, SLOT(close()));
+	close_application_shortcut_->setAutoRepeat(false);
+
+	close_current_tab_shortcut_ = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_W), this, SLOT(on_close_current_tab()));
+
 	connect(new_session_button_, SIGNAL(clicked(bool)),
 		this, SLOT(on_new_session_clicked()));
 	connect(run_stop_button_, SIGNAL(clicked(bool)),
@@ -740,6 +745,13 @@ void MainWindow::on_actionAbout_triggered()
 {
 	dialogs::About dlg(device_manager_.context(), this);
 	dlg.exec();
+}
+
+void MainWindow::on_close_current_tab()
+{
+	int tab = session_selector_.currentIndex();
+
+	on_tab_close_requested(tab);
 }
 
 } // namespace pv

--- a/pv/mainwindow.hpp
+++ b/pv/mainwindow.hpp
@@ -28,6 +28,7 @@
 #include <QSignalMapper>
 #include <QToolButton>
 #include <QTabWidget>
+#include <QShortcut>
 
 #include "session.hpp"
 #include "views/viewbase.hpp"
@@ -151,6 +152,8 @@ private:
 	QIcon icon_red_;
 	QIcon icon_green_;
 	QIcon icon_grey_;
+
+	QShortcut *run_stop_shortcut_;
 };
 
 } // namespace pv

--- a/pv/mainwindow.hpp
+++ b/pv/mainwindow.hpp
@@ -130,6 +130,8 @@ private Q_SLOTS:
 
 	void on_actionAbout_triggered();
 
+	void on_close_current_tab();
+
 private:
 	DeviceManager &device_manager_;
 
@@ -154,6 +156,8 @@ private:
 	QIcon icon_grey_;
 
 	QShortcut *run_stop_shortcut_;
+	QShortcut *close_application_shortcut_;
+	QShortcut *close_current_tab_shortcut_;
 };
 
 } // namespace pv


### PR DESCRIPTION
This is a proposed solution to reenable the <Space> shortcut for
Run/Stop. It seems that setShortcut on QToolButton is not working, but
it seems that adding QShortcut works as a workaround.

If there is a better solution or if @abraxa has an idea why the other shortcut does not work I am happy to implement an alternative.