### PR TITLE
Bring back sticky scroll and coloured background shortcuts.

### DIFF
--- a/pv/mainwindow.cpp
+++ b/pv/mainwindow.cpp
@@ -74,8 +74,6 @@ MainWindow::MainWindow(DeviceManager &device_manager,
 	device_manager_(device_manager),
 	session_selector_(this),
 	session_state_mapper_(this),
-	action_view_sticky_scrolling_(new QAction(this)),
-	action_view_coloured_bg_(new QAction(this)),
 	action_about_(new QAction(this)),
 	icon_red_(":/icons/status-red.svg"),
 	icon_green_(":/icons/status-green.svg"),
@@ -117,16 +115,6 @@ MainWindow::~MainWindow()
 {
 	while (!sessions_.empty())
 		remove_session(sessions_.front());
-}
-
-QAction* MainWindow::action_view_sticky_scrolling() const
-{
-	return action_view_sticky_scrolling_;
-}
-
-QAction* MainWindow::action_view_coloured_bg() const
-{
-	return action_view_coloured_bg_;
 }
 
 QAction* MainWindow::action_about() const
@@ -201,8 +189,8 @@ shared_ptr<views::ViewBase> MainWindow::add_view(const QString &title,
 				qobject_cast<views::ViewBase*>(v.get()),
 				SLOT(trigger_event(util::Timestamp)));
 
-			v->enable_sticky_scrolling(action_view_sticky_scrolling_->isChecked());
-			v->enable_coloured_bg(action_view_coloured_bg_->isChecked());
+			v->enable_sticky_scrolling(true);
+			v->enable_coloured_bg(true);
 
 			shared_ptr<MainBar> main_bar = session.main_bar();
 			if (!main_bar) {
@@ -344,19 +332,11 @@ void MainWindow::setup_ui()
 	icon.addFile(QString(":/icons/sigrok-logo-notext.png"));
 	setWindowIcon(icon);
 
-	action_view_sticky_scrolling_->setCheckable(true);
-	action_view_sticky_scrolling_->setChecked(true);
-	action_view_sticky_scrolling_->setShortcut(QKeySequence(Qt::Key_S));
-	action_view_sticky_scrolling_->setObjectName(
-		QString::fromUtf8("actionViewStickyScrolling"));
-	action_view_sticky_scrolling_->setText(tr("&Sticky Scrolling"));
+	view_sticky_scrolling_shortcut_ = new QShortcut(QKeySequence(Qt::Key_S), this, SLOT(on_view_sticky_scrolling_shortcut()));
+	view_sticky_scrolling_shortcut_->setAutoRepeat(false);
 
-	action_view_coloured_bg_->setCheckable(true);
-	action_view_coloured_bg_->setChecked(true);
-	action_view_coloured_bg_->setShortcut(QKeySequence(Qt::Key_B));
-	action_view_coloured_bg_->setObjectName(
-		QString::fromUtf8("actionViewColouredBg"));
-	action_view_coloured_bg_->setText(tr("Use &Coloured Backgrounds"));
+	view_coloured_bg_shortcut_ = new QShortcut(QKeySequence(Qt::Key_B), this, SLOT(on_view_coloured_bg_shortcut()));
+	view_coloured_bg_shortcut_->setAutoRepeat(false);
 
 	action_about_->setObjectName(QString::fromUtf8("actionAbout"));
 	action_about_->setToolTip(tr("&About..."));
@@ -723,22 +703,22 @@ void MainWindow::on_tab_close_requested(int index)
 		remove_session(session);
 }
 
-void MainWindow::on_actionViewStickyScrolling_triggered()
+void MainWindow::on_view_sticky_scrolling_shortcut()
 {
 	shared_ptr<views::ViewBase> viewbase = get_active_view();
 	views::TraceView::View* view =
 		qobject_cast<views::TraceView::View*>(viewbase.get());
 	if (view)
-		view->enable_sticky_scrolling(action_view_sticky_scrolling_->isChecked());
+		view->toggle_sticky_scrolling();
 }
 
-void MainWindow::on_actionViewColouredBg_triggered()
+void MainWindow::on_view_coloured_bg_shortcut()
 {
 	shared_ptr<views::ViewBase> viewbase = get_active_view();
 	views::TraceView::View* view =
 			qobject_cast<views::TraceView::View*>(viewbase.get());
 	if (view)
-		view->enable_coloured_bg(action_view_coloured_bg_->isChecked());
+		view->toggle_coloured_bg();
 }
 
 void MainWindow::on_actionAbout_triggered()

--- a/pv/mainwindow.hpp
+++ b/pv/mainwindow.hpp
@@ -71,8 +71,6 @@ public:
 
 	~MainWindow();
 
-	QAction* action_view_sticky_scrolling() const;
-	QAction* action_view_coloured_bg() const;
 	QAction* action_about() const;
 
 	std::shared_ptr<views::ViewBase> get_active_view() const;
@@ -124,9 +122,9 @@ private Q_SLOTS:
 	void on_tab_changed(int index);
 	void on_tab_close_requested(int index);
 
-	void on_actionViewStickyScrolling_triggered();
+	void on_view_sticky_scrolling_shortcut();
 
-	void on_actionViewColouredBg_triggered();
+	void on_view_coloured_bg_shortcut();
 
 	void on_actionAbout_triggered();
 
@@ -147,14 +145,14 @@ private:
 	QTabWidget session_selector_;
 	QSignalMapper session_state_mapper_;
 
-	QAction *const action_view_sticky_scrolling_;
-	QAction *const action_view_coloured_bg_;
 	QAction *const action_about_;
 
 	QIcon icon_red_;
 	QIcon icon_green_;
 	QIcon icon_grey_;
 
+	QShortcut *view_sticky_scrolling_shortcut_;
+	QShortcut *view_coloured_bg_shortcut_;
 	QShortcut *run_stop_shortcut_;
 	QShortcut *close_application_shortcut_;
 	QShortcut *close_current_tab_shortcut_;

--- a/pv/view/view.cpp
+++ b/pv/view/view.cpp
@@ -145,6 +145,7 @@ View::View(Session &session, QWidget *parent) :
 	offset_(0),
 	updating_scroll_(false),
 	sticky_scrolling_(false), // Default setting is set in MainWindow::setup_ui()
+	coloured_bg_(false),
 	always_zoom_to_fit_(false),
 	tick_period_(0),
 	tick_prefix_(pv::util::SIPrefix::yocto),
@@ -563,10 +564,22 @@ void View::enable_sticky_scrolling(bool state)
 	sticky_scrolling_ = state;
 }
 
+void View::toggle_sticky_scrolling(void)
+{
+	sticky_scrolling_ = !sticky_scrolling_;
+}
+
+bool View::get_coloured_bg(void)
+{
+	return coloured_bg_;
+}
+
 void View::enable_coloured_bg(bool state)
 {
 	const vector<shared_ptr<TraceTreeItem>> items(
 		list_by_type<TraceTreeItem>());
+
+	coloured_bg_ = state;
 
 	for (shared_ptr<TraceTreeItem> i : items) {
 		// Can't cast to Trace because it's abstract, so we need to
@@ -588,6 +601,11 @@ void View::enable_coloured_bg(bool state)
 	}
 
 	viewport_->update();
+}
+
+void View::toggle_coloured_bg(void)
+{
+	enable_coloured_bg(!coloured_bg_);
 }
 
 bool View::cursors_shown() const

--- a/pv/view/view.hpp
+++ b/pv/view/view.hpp
@@ -206,10 +206,25 @@ public:
 	void enable_sticky_scrolling(bool state);
 
 	/**
+	 * Toggle sticky scrolling.
+	 */
+	void toggle_sticky_scrolling(void);
+
+	/**
+	 * Get current coloured_bg state. Returns true if coloured backgrounds are enabled.
+	 */
+	bool get_coloured_bg(void);
+
+	/**
 	 * Enables or disables coloured trace backgrounds. If they're not
 	 * coloured then they will use alternating colors.
 	 */
 	void enable_coloured_bg(bool state);
+
+	/**
+	 * Toggle coloured backgrounds.
+	 */
+	void toggle_coloured_bg(void);
 
 	/**
 	 * Returns true if cursors are displayed. false otherwise.
@@ -401,6 +416,7 @@ private:
 
 	bool updating_scroll_;
 	bool sticky_scrolling_;
+	bool coloured_bg_;
 	bool always_zoom_to_fit_;
 	QTimer delayed_view_updater_;
 


### PR DESCRIPTION
Converted the actions to QShortcut. We do not use the actions anywhere
else in the code and they were not being triggered using the setShortcut
setting. Additionally expanded the view background color to be a
toggleable attribute.