### PR TITLE
Session: Fix mismatched delete operator.

### DIFF
--- a/pv/session.cpp
+++ b/pv/session.cpp
@@ -1097,7 +1097,7 @@ void Session::feed_in_analog(shared_ptr<Analog> analog)
 	const size_t sample_count = analog->num_samples() / channel_count;
 	bool sweep_beginning = false;
 
-	unique_ptr<float> data(new float[analog->num_samples()]);
+	unique_ptr<float[]> data(new float[analog->num_samples()]);
 	analog->get_data_as_float(data.get());
 
 	if (signalbases_.empty())


### PR DESCRIPTION
Valgrind reported this here:

Mismatched free() / delete / delete []
   at 0x4C2D31B: operator delete(void*) (vg_replace_malloc.c:576)
   by 0x1C76D0: operator() (unique_ptr.h:78)
   by 0x1C76D0: ~unique_ptr (unique_ptr.h:268)
   by 0x1C76D0: pv::data::AnalogSegment::append_interleaved_samples(float const*, unsigned long, unsigned long) (analogsegment.cpp:78)
   by 0x1AFDD5: pv::Session::feed_in_analog(std::shared_ptr<sigrok::Analog>) (session.cpp:1142)
   by 0x1B043C: pv::Session::data_feed_in(std::shared_ptr<sigrok::Device>, std::shared_ptr<sigrok::Packet>) (session.cpp:1187)
...
 Address 0x1cbf6b90 is 0 bytes inside a block of size 940 alloc'd
   at 0x4C2C97F: operator new[](unsigned long) (vg_replace_malloc.c:423)
   by 0x1C765E: pv::data::AnalogSegment::append_interleaved_samples(float const*, unsigned long, unsigned long) (analogsegment.cpp:78)
   by 0x1AFDD5: pv::Session::feed_in_analog(std::shared_ptr<sigrok::Analog>) (session.cpp:1142)