### PR TITLE
fix catching polymorphic types by value

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -226,7 +226,7 @@ int main(int argc, char *argv[])
 			// Run the application
 			ret = a.exec();
 
-		} catch (exception e) {
+		} catch (exception& e) {
 			qDebug() << e.what();
 		}
 

--- a/pv/binding/device.cpp
+++ b/pv/binding/device.cpp
@@ -68,7 +68,7 @@ Device::Device(shared_ptr<sigrok::Configurable> configurable) :
 		string name_str;
 		try {
 			name_str = key->description();
-		} catch (Error e) {
+		} catch (Error& e) {
 			name_str = key->name();
 		}
 

--- a/pv/data/decodesignal.cpp
+++ b/pv/data/decodesignal.cpp
@@ -361,7 +361,7 @@ int64_t DecodeSignal::get_working_sample_count(uint32_t segment_id) const
 			try {
 				const shared_ptr<LogicSegment> segment = logic_data->logic_segments().at(segment_id);
 				count = min(count, (int64_t)segment->get_sample_count());
-			} catch (out_of_range) {
+			} catch (out_of_range&) {
 				return 0;
 			}
 		}
@@ -378,7 +378,7 @@ int64_t DecodeSignal::get_decoded_sample_count(uint32_t segment_id) const
 	try {
 		const DecodeSegment *segment = &(segments_.at(segment_id));
 		result = segment->samples_decoded;
-	} catch (out_of_range) {
+	} catch (out_of_range&) {
 		// Do nothing
 	}
 
@@ -431,7 +431,7 @@ void DecodeSignal::get_annotation_subset(
 		if (iter != rows->end())
 			(*iter).second.get_annotation_subset(dest,
 				start_sample, end_sample);
-	} catch (out_of_range) {
+	} catch (out_of_range&) {
 		// Do nothing
 	}
 }
@@ -607,7 +607,7 @@ uint32_t DecodeSignal::get_input_samplerate(uint32_t segment_id) const
 			try {
 				const shared_ptr<LogicSegment> segment = logic_data->logic_segments().at(segment_id);
 				samplerate = segment->samplerate();
-			} catch (out_of_range) {
+			} catch (out_of_range&) {
 				// Do nothing
 			}
 			break;
@@ -736,7 +736,7 @@ void DecodeSignal::mux_logic_samples(uint32_t segment_id, const int64_t start, c
 			shared_ptr<LogicSegment> segment;
 			try {
 				segment = logic_data->logic_segments().at(segment_id);
-			} catch (out_of_range) {
+			} catch (out_of_range&) {
 				qDebug() << "Muxer error for" << name() << ":" << ch.assigned_signal->name() \
 					<< "has no logic segment" << segment_id;
 				return;
@@ -756,7 +756,7 @@ void DecodeSignal::mux_logic_samples(uint32_t segment_id, const int64_t start, c
 	shared_ptr<LogicSegment> output_segment;
 	try {
 		output_segment = logic_mux_data_->logic_segments().at(segment_id);
-	} catch (out_of_range) {
+	} catch (out_of_range&) {
 		qDebug() << "Muxer error for" << name() << ": no logic mux segment" \
 			<< segment_id << "in mux_logic_samples(), mux segments size is" \
 			<< logic_mux_data_->logic_segments().size();
@@ -948,7 +948,7 @@ void DecodeSignal::decode_proc()
 
 				try {
 					input_segment = logic_mux_data_->logic_segments().at(current_segment_id_);
-				} catch (out_of_range) {
+				} catch (out_of_range&) {
 					qDebug() << "Decode error for" << name() << ": no logic mux segment" \
 						<< current_segment_id_ << "in decode_proc(), mux segments size is" \
 						<< logic_mux_data_->logic_segments().size();

--- a/pv/data/signalbase.cpp
+++ b/pv/data/signalbase.cpp
@@ -219,7 +219,7 @@ bool SignalBase::segment_is_complete(uint32_t segment_id) const
 		auto segments = data->analog_segments();
 		try {
 			result = segments.at(segment_id)->is_complete();
-		} catch (out_of_range) {
+		} catch (out_of_range&) {
 			// Do nothing
 		}
 	}
@@ -230,7 +230,7 @@ bool SignalBase::segment_is_complete(uint32_t segment_id) const
 		auto segments = data->logic_segments();
 		try {
 			result = segments.at(segment_id)->is_complete();
-		} catch (out_of_range) {
+		} catch (out_of_range&) {
 			// Do nothing
 		}
 	}
@@ -617,7 +617,7 @@ void SignalBase::conversion_thread_proc()
 
 			try {
 				asegment = analog_data->analog_segments().at(segment_id).get();
-			} catch (out_of_range) {
+			} catch (out_of_range&) {
 				qDebug() << "Conversion error for" << name() << ": no analog segment" \
 					<< segment_id << ", segments size is" << analog_data->analog_segments().size();
 				return;

--- a/pv/devices/inputfile.cpp
+++ b/pv/devices/inputfile.cpp
@@ -74,7 +74,7 @@ void InputFile::open()
 
 	try {
 		device_ = input_->device();
-	} catch (sigrok::Error) {
+	} catch (sigrok::Error&) {
 		return;
 	}
 

--- a/pv/popups/channels.cpp
+++ b/pv/popups/channels.cpp
@@ -208,7 +208,7 @@ void Channels::showEvent(QShowEvent *event)
 		try {
 			QLabel* label = group_label_map_.at(group);
 			label->setText(QString("<h3>%1</h3>").arg(group->name().c_str()));
-		} catch (out_of_range) {
+		} catch (out_of_range&) {
 			// Do nothing
 		}
 	}

--- a/pv/session.cpp
+++ b/pv/session.cpp
@@ -521,7 +521,7 @@ void Session::load_file(QString file_name,
 				new devices::SessionFile(
 					device_manager_.context(),
 					file_name.toStdString())));
-	} catch (Error e) {
+	} catch (Error& e) {
 		main_bar_->session_error(tr("Failed to load ") + file_name, e.what());
 		set_default_device();
 		main_bar_->update_device_list();
@@ -732,7 +732,7 @@ shared_ptr<data::DecodeSignal> Session::add_decode_signal()
 		// Add the decode signal to all views
 		for (shared_ptr<views::ViewBase> view : views_)
 			view->add_decode_signal(signal);
-	} catch (runtime_error e) {
+	} catch (runtime_error& e) {
 		remove_decode_signal(signal);
 		return nullptr;
 	}
@@ -934,7 +934,7 @@ void Session::sample_thread_proc(function<void (const QString)> error_handler)
 
 	try {
 		device_->start();
-	} catch (Error e) {
+	} catch (Error& e) {
 		error_handler(e.what());
 		return;
 	}
@@ -944,7 +944,7 @@ void Session::sample_thread_proc(function<void (const QString)> error_handler)
 
 	try {
 		device_->run();
-	} catch (Error e) {
+	} catch (Error& e) {
 		error_handler(e.what());
 		set_capture_state(Stopped);
 		return;
@@ -1253,7 +1253,7 @@ void Session::data_feed_in(shared_ptr<sigrok::Device> device,
 	case SR_DF_LOGIC:
 		try {
 			feed_in_logic(dynamic_pointer_cast<Logic>(packet->payload()));
-		} catch (bad_alloc) {
+		} catch (bad_alloc&) {
 			out_of_memory_ = true;
 			device_->stop();
 		}
@@ -1262,7 +1262,7 @@ void Session::data_feed_in(shared_ptr<sigrok::Device> device,
 	case SR_DF_ANALOG:
 		try {
 			feed_in_analog(dynamic_pointer_cast<Analog>(packet->payload()));
-		} catch (bad_alloc) {
+		} catch (bad_alloc&) {
 			out_of_memory_ = true;
 			device_->stop();
 		}

--- a/pv/storesession.cpp
+++ b/pv/storesession.cpp
@@ -182,7 +182,7 @@ bool StoreSession::start()
 			{{ConfigKey::SAMPLERATE, Glib::Variant<guint64>::create(
 				any_segment->samplerate())}});
 		output_->receive(meta);
-	} catch (Error error) {
+	} catch (Error& error) {
 		error_ = tr("Error while saving: ") + error.what();
 		return false;
 	}
@@ -276,7 +276,7 @@ void StoreSession::store_proc(vector< shared_ptr<data::SignalBase> > achannel_li
 
 				delete[] ldata;
 			}
-		} catch (Error error) {
+		} catch (Error& error) {
 			error_ = tr("Error while saving: ") + error.what();
 			break;
 		}

--- a/pv/toolbars/mainbar.cpp
+++ b/pv/toolbars/mainbar.cpp
@@ -305,7 +305,7 @@ void MainBar::update_sample_rate_selector()
 	if (sr_dev->config_check(ConfigKey::SAMPLERATE, Capability::LIST)) {
 		try {
 			gvar_dict = sr_dev->config_list(ConfigKey::SAMPLERATE);
-		} catch (Error error) {
+		} catch (Error& error) {
 			qDebug() << tr("Failed to get sample rate list:") << error.what();
 		}
 	} else {
@@ -368,7 +368,7 @@ void MainBar::update_sample_rate_selector_value()
 		updating_sample_rate_ = true;
 		sample_rate_.set_value(samplerate);
 		updating_sample_rate_ = false;
-	} catch (Error error) {
+	} catch (Error& error) {
 		qDebug() << tr("Failed to get value of sample rate:") << error.what();
 	}
 }
@@ -409,7 +409,7 @@ void MainBar::update_sample_count_selector()
 			if (gvar.gobj())
 				g_variant_get(gvar.gobj(), "(tt)",
 					&min_sample_count, &max_sample_count);
-		} catch (Error error) {
+		} catch (Error& error) {
 			qDebug() << tr("Failed to get sample limit list:") << error.what();
 		}
 	}
@@ -501,7 +501,7 @@ void MainBar::commit_sample_rate()
 		sr_dev->config_set(ConfigKey::SAMPLERATE,
 			Glib::Variant<guint64>::create(sample_rate));
 		update_sample_rate_selector();
-	} catch (Error error) {
+	} catch (Error& error) {
 		qDebug() << tr("Failed to configure samplerate:") << error.what();
 		return;
 	}
@@ -528,7 +528,7 @@ void MainBar::commit_sample_count()
 			sr_dev->config_set(ConfigKey::LIMIT_SAMPLES,
 				Glib::Variant<guint64>::create(sample_count));
 			update_sample_count_selector();
-		} catch (Error error) {
+		} catch (Error& error) {
 			qDebug() << tr("Failed to configure sample count:") << error.what();
 			return;
 		}

--- a/pv/views/trace/analogsignal.cpp
+++ b/pv/views/trace/analogsignal.cpp
@@ -669,7 +669,7 @@ shared_ptr<pv::data::AnalogSegment> AnalogSignal::get_analog_segment_to_paint() 
 				(segment_display_mode_ == ShowLastCompleteSegmentOnly)) {
 			try {
 				segment = segments.at(current_segment_);
-			} catch (out_of_range) {
+			} catch (out_of_range&) {
 				qDebug() << "Current analog segment out of range for signal" << base_->name() << ":" << current_segment_;
 			}
 		}
@@ -693,7 +693,7 @@ shared_ptr<pv::data::LogicSegment> AnalogSignal::get_logic_segment_to_paint() co
 				(segment_display_mode_ == ShowLastCompleteSegmentOnly)) {
 			try {
 				segment = segments.at(current_segment_);
-			} catch (out_of_range) {
+			} catch (out_of_range&) {
 				qDebug() << "Current logic segment out of range for signal" << base_->name() << ":" << current_segment_;
 			}
 		}

--- a/pv/views/trace/decodetrace.cpp
+++ b/pv/views/trace/decodetrace.cpp
@@ -220,7 +220,7 @@ void DecodeTrace::paint_mid(QPainter &p, ViewItemPaintParams &pp)
 		int row_title_width;
 		try {
 			row_title_width = row_title_widths_.at(row);
-		} catch (out_of_range) {
+		} catch (out_of_range&) {
 			const int w = p.boundingRect(QRectF(), 0, row.title()).width() +
 				RowTitleMargin;
 			row_title_widths_[row] = w;

--- a/pv/views/trace/logicsignal.cpp
+++ b/pv/views/trace/logicsignal.cpp
@@ -362,7 +362,7 @@ shared_ptr<pv::data::LogicSegment> LogicSignal::get_logic_segment_to_paint() con
 		(segment_display_mode_ == ShowLastCompleteSegmentOnly)) {
 			try {
 				segment = segments.at(current_segment_);
-			} catch (out_of_range) {
+			} catch (out_of_range&) {
 				qDebug() << "Current logic segment out of range for signal" << base_->name() << ":" << current_segment_;
 			}
 		}


### PR DESCRIPTION
Compiling with GCC 8 produces a new warning about catching polymorphic
types by value. Proper way is to use references instead.

````
/home/sharkcz/projects/pulseview/main.cpp: In function ‘int main(int, char**)’:
/home/sharkcz/projects/pulseview/main.cpp:229:22: error: catching polymorphic type ‘class std::exception’ by value [-Werror=catch-value=]
   } catch (exception e) {
                      ^
cc1plus: all warnings being treated as errors
````