### PR TITLE
 Speed up downsampling in logicsegment 

### DIFF
--- a/pv/data/logicsegment.cpp
+++ b/pv/data/logicsegment.cpp
@@ -71,7 +71,7 @@ template <class T>
 void LogicSegment::downsampleTmain(const T*&in, T &acc, T &prev)
 {
 	// Accumulate one sample at a time
-	for(uint64_t i=0; i<MipMapScaleFactor; i++) {
+	for (uint64_t i = 0; i < MipMapScaleFactor; i++) {
 		T sample = *in++;
 		acc |= prev ^ sample;
 		prev = sample;
@@ -85,7 +85,7 @@ void LogicSegment::downsampleTmain<uint8_t>(const uint8_t*&in, uint8_t &acc, uin
 	uint32_t prev32 = prev | prev << 8 | prev << 16 | prev << 24;
 	uint32_t acc32 = acc;
 	const uint32_t *in32 = (const uint32_t*)in;
-	for(uint64_t i=0; i<MipMapScaleFactor; i+=4) {
+	for (uint64_t i = 0; i < MipMapScaleFactor; i+=4) {
 		uint32_t sample32 = *in32++;
 		acc32 |= prev32 ^ sample32;
 		prev32 = sample32;
@@ -112,7 +112,7 @@ void LogicSegment::downsampleTmain<uint16_t>(const uint16_t*&in, uint16_t &acc, 
 	uint32_t prev32 = prev | prev << 16;
 	uint32_t acc32 = acc;
 	const uint32_t *in32 = (const uint32_t*)in;
-	for(uint64_t i=0; i<MipMapScaleFactor; i+=2) {
+	for (uint64_t i = 0; i < MipMapScaleFactor; i+=2) {
 		uint32_t sample32 = *in32++;
 		acc32 |= prev32 ^ sample32;
 		prev32 = sample32;
@@ -140,7 +140,7 @@ void LogicSegment::downsampleT(const uint8_t *in_, uint8_t *&out_, uint64_t len)
 
 	// Try to complete the previous downsample
 	if (last_append_extra_) {
-		while(last_append_extra_<MipMapScaleFactor && len>0) {
+		while (last_append_extra_ < MipMapScaleFactor && len > 0) {
 			T sample = *in++;
 			acc |= prev ^ sample;
 			prev = sample;
@@ -160,7 +160,7 @@ void LogicSegment::downsampleT(const uint8_t *in_, uint8_t *&out_, uint64_t len)
 	}
 
 	// Handle complete blocks of MipMapScaleFactor samples
-	while(len >= MipMapScaleFactor) {
+	while (len >= MipMapScaleFactor) {
 		downsampleTmain<T>(in, acc, prev);
 		len -= MipMapScaleFactor;
 		// Output downsample
@@ -169,7 +169,7 @@ void LogicSegment::downsampleT(const uint8_t *in_, uint8_t *&out_, uint64_t len)
 	}
 
 	// Process remainder, not enough for a complete sample
-	while(len > 0) {
+	while (len > 0) {
 		T sample = *in++;
 		acc |= prev ^ sample;
 		prev = sample;
@@ -192,7 +192,7 @@ void LogicSegment::downsampleGeneric(const uint8_t *in, uint8_t *&out, uint64_t 
 
 	// Try to complete the previous downsample
 	if (last_append_extra_) {
-		while(last_append_extra_<MipMapScaleFactor && len>0) {
+		while (last_append_extra_ < MipMapScaleFactor && len > 0) {
 			const uint64_t sample = unpack_sample(in);
 			in += unit_size_;
 			acc |= prev ^ sample;
@@ -214,9 +214,9 @@ void LogicSegment::downsampleGeneric(const uint8_t *in, uint8_t *&out, uint64_t 
 	}
 
 	// Handle complete blocks of MipMapScaleFactor samples
-	while(len >= MipMapScaleFactor) {
+	while (len >= MipMapScaleFactor) {
 		// Accumulate one sample at a time
-		for(uint64_t i=0; i<MipMapScaleFactor; i++) {
+		for (uint64_t i = 0; i < MipMapScaleFactor; i++) {
 			const uint64_t sample = unpack_sample(in);
 			in += unit_size_;
 			acc |= prev ^ sample;
@@ -230,7 +230,7 @@ void LogicSegment::downsampleGeneric(const uint8_t *in, uint8_t *&out, uint64_t 
 	}
 
 	// Process remainder, not enough for a complete sample
-	while(len > 0) {
+	while (len > 0) {
 		const uint64_t sample = unpack_sample(in);
 		in += unit_size_;
 		acc |= prev ^ sample;
@@ -614,7 +614,7 @@ void LogicSegment::append_payload_to_mipmap()
 	const uint64_t end_sample = m0.length * MipMapScaleFactor;
 	uint64_t len_sample = end_sample - start_sample;
 	it = begin_sample_iteration(start_sample);
-	while(len_sample > 0) {
+	while (len_sample > 0) {
 		// Number of samples available in this chunk
 		uint64_t count = get_iterator_valid_length(it);
 		// Reduce if less than asked for

--- a/pv/data/logicsegment.cpp
+++ b/pv/data/logicsegment.cpp
@@ -56,7 +56,6 @@ LogicSegment::LogicSegment(pv::data::Logic& owner, uint32_t segment_id,
 	last_append_sample_(0),
 	last_append_accumulator_(0),
 	last_append_extra_(0)
-
 {
 	memset(mip_map_, 0, sizeof(mip_map_));
 }

--- a/pv/data/logicsegment.cpp
+++ b/pv/data/logicsegment.cpp
@@ -53,7 +53,10 @@ LogicSegment::LogicSegment(pv::data::Logic& owner, uint32_t segment_id,
 	unsigned int unit_size,	uint64_t samplerate) :
 	Segment(segment_id, samplerate, unit_size),
 	owner_(owner),
-	last_append_sample_(0)
+	last_append_sample_(0),
+	last_append_accumulator_(0),
+	last_append_extra_(0)
+
 {
 	memset(mip_map_, 0, sizeof(mip_map_));
 }
@@ -63,6 +66,183 @@ LogicSegment::~LogicSegment()
 	lock_guard<recursive_mutex> lock(mutex_);
 	for (MipMapLevel &l : mip_map_)
 		free(l.data);
+}
+
+template <class T>
+void LogicSegment::downsampleTmain(const T*&in, T &acc, T &prev)
+{
+	// Accumulate one sample at a time
+	for(uint64_t i=0; i<MipMapScaleFactor; i++) {
+		T sample = *in++;
+		acc |= prev ^ sample;
+		prev = sample;
+	}
+}
+
+template <>
+void LogicSegment::downsampleTmain<uint8_t>(const uint8_t*&in, uint8_t &acc, uint8_t &prev)
+{
+	// Handle 8 bit samples in 32 bit steps
+	uint32_t prev32 = prev | prev << 8 | prev << 16 | prev << 24;
+	uint32_t acc32 = acc;
+	const uint32_t *in32 = (const uint32_t*)in;
+	for(uint64_t i=0; i<MipMapScaleFactor; i+=4) {
+		uint32_t sample32 = *in32++;
+		acc32 |= prev32 ^ sample32;
+		prev32 = sample32;
+	}
+	// Reduce result back to uint8_t
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+	prev = (prev32 >> 24) & 0xff; // MSB is last
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+	prev = prev32 & 0xff; // LSB is last
+#else
+#error Endian unknown
+#endif
+	acc |= acc32 & 0xff;
+	acc |= (acc32 >> 8) & 0xff;
+	acc |= (acc32 >> 16) & 0xff;
+	acc |= (acc32 >> 24) & 0xff;
+	in = (const uint8_t*)in32;
+}
+
+template <>
+void LogicSegment::downsampleTmain<uint16_t>(const uint16_t*&in, uint16_t &acc, uint16_t &prev)
+{
+	// Handle 16 bit samples in 32 bit steps
+	uint32_t prev32 = prev | prev << 16;
+	uint32_t acc32 = acc;
+	const uint32_t *in32 = (const uint32_t*)in;
+	for(uint64_t i=0; i<MipMapScaleFactor; i+=2) {
+		uint32_t sample32 = *in32++;
+		acc32 |= prev32 ^ sample32;
+		prev32 = sample32;
+	}
+	// Reduce result back to uint16_t
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+	prev = (prev32 >> 16) & 0xffff; // MSB is last
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+	prev = prev32 & 0xffff; // LSB is last
+#else
+#error Endian unknown
+#endif
+	acc |= acc32 & 0xffff;
+	acc |= (acc32 >> 16) & 0xffff;
+	in = (const uint16_t*)in32;
+}
+
+template <class T>
+void LogicSegment::downsampleT(const uint8_t *in_, uint8_t *&out_, uint64_t len)
+{
+	const T *in = (const T*)in_;
+	T *out = (T*)out_;
+	T prev = last_append_sample_;
+	T acc = last_append_accumulator_;
+
+	// Try to complete the previous downsample
+	if (last_append_extra_) {
+		while(last_append_extra_<MipMapScaleFactor && len>0) {
+			T sample = *in++;
+			acc |= prev ^ sample;
+			prev = sample;
+			last_append_extra_++;
+			len--;
+		}
+		if (!len) {
+			// Not enough samples available to complete downsample
+			last_append_sample_ = prev;
+			last_append_accumulator_ = acc;
+			return;
+		}
+		// We have a complete downsample
+		*out++ = acc;
+		acc = 0;
+		last_append_extra_ = 0;
+	}
+
+	// Handle complete blocks of MipMapScaleFactor samples
+	while(len >= MipMapScaleFactor) {
+		downsampleTmain<T>(in, acc, prev);
+		len -= MipMapScaleFactor;
+		// Output downsample
+		*out++ = acc;
+		acc = 0;
+	}
+
+	// Process remainder, not enough for a complete sample
+	while(len > 0) {
+		T sample = *in++;
+		acc |= prev ^ sample;
+		prev = sample;
+		last_append_extra_++;
+		len--;
+	}
+
+	// Update context
+	last_append_sample_ = prev;
+	last_append_accumulator_ = acc;
+	out_ = (uint8_t *)out;
+}
+
+void LogicSegment::downsampleGeneric(const uint8_t *in, uint8_t *&out, uint64_t len)
+{
+	// Downsample using the generic unpack_sample()
+	// which can handle any width between 1 and 8 bytes
+	uint64_t prev = last_append_sample_;
+	uint64_t acc = last_append_accumulator_;
+
+	// Try to complete the previous downsample
+	if (last_append_extra_) {
+		while(last_append_extra_<MipMapScaleFactor && len>0) {
+			const uint64_t sample = unpack_sample(in);
+			in += unit_size_;
+			acc |= prev ^ sample;
+			prev = sample;
+			last_append_extra_++;
+			len--;
+		}
+		if (!len) {
+			// Not enough samples available to complete downsample
+			last_append_sample_ = prev;
+			last_append_accumulator_ = acc;
+			return;
+		}
+		// We have a complete downsample
+		pack_sample(out, acc);
+		out += unit_size_;
+		acc = 0;
+		last_append_extra_ = 0;
+	}
+
+	// Handle complete blocks of MipMapScaleFactor samples
+	while(len >= MipMapScaleFactor) {
+		// Accumulate one sample at a time
+		for(uint64_t i=0; i<MipMapScaleFactor; i++) {
+			const uint64_t sample = unpack_sample(in);
+			in += unit_size_;
+			acc |= prev ^ sample;
+			prev = sample;
+		}
+		len -= MipMapScaleFactor;
+		// Output downsample
+		pack_sample(out, acc);
+		out += unit_size_;
+		acc = 0;
+	}
+
+	// Process remainder, not enough for a complete sample
+	while(len > 0) {
+		const uint64_t sample = unpack_sample(in);
+		in += unit_size_;
+		acc |= prev ^ sample;
+		prev = sample;
+		last_append_extra_++;
+		len--;
+	}
+
+	// Update context
+	last_append_sample_ = prev;
+	last_append_accumulator_ = acc;
 }
 
 inline uint64_t LogicSegment::unpack_sample(const uint8_t *ptr) const
@@ -433,22 +613,28 @@ void LogicSegment::append_payload_to_mipmap()
 	// Iterate through the samples to populate the first level mipmap
 	const uint64_t start_sample = prev_length * MipMapScaleFactor;
 	const uint64_t end_sample = m0.length * MipMapScaleFactor;
-
+	uint64_t len_sample = end_sample - start_sample;
 	it = begin_sample_iteration(start_sample);
-	for (uint64_t i = start_sample; i < end_sample;) {
-		// Accumulate transitions which have occurred in this sample
-		accumulator = 0;
-		diff_counter = MipMapScaleFactor;
-		while (diff_counter-- > 0) {
-			const uint64_t sample = unpack_sample(get_iterator_value(it));
-			accumulator |= last_append_sample_ ^ sample;
-			last_append_sample_ = sample;
-			continue_sample_iteration(it, 1);
-			i++;
-		}
-
-		pack_sample(dest_ptr, accumulator);
-		dest_ptr += unit_size_;
+	while(len_sample > 0) {
+		// Number of samples available in this chunk
+		uint64_t count = get_iterator_valid_length(it);
+		// Reduce if less than asked for
+		count = std::min(count, len_sample);
+		uint8_t *src_ptr = get_iterator_value(it);
+		// Submit these contiguous samples to downsampling in bulk
+		if (unit_size_ == 1)
+			downsampleT<uint8_t>(src_ptr, dest_ptr, count);
+		else if (unit_size_ == 2)
+			downsampleT<uint16_t>(src_ptr, dest_ptr, count);
+		else if (unit_size_ == 4)
+			downsampleT<uint32_t>(src_ptr, dest_ptr, count);
+		else if (unit_size_ == 8)
+			downsampleT<uint8_t>(src_ptr, dest_ptr, count);
+		else
+			downsampleGeneric(src_ptr, dest_ptr, count);
+		len_sample -= count;
+		// Advance iterator, should move to start of next chunk
+		continue_sample_iteration(it, count);
 	}
 	end_sample_iteration(it);
 

--- a/pv/data/logicsegment.hpp
+++ b/pv/data/logicsegment.hpp
@@ -107,6 +107,10 @@ private:
 
 	uint64_t get_unpacked_sample(uint64_t index) const;
 
+	template <class T> void downsampleTmain(const T*&in, T &acc, T &prev);
+	template <class T> void downsampleT(const uint8_t *in, uint8_t *&out, uint64_t len);
+	void downsampleGeneric(const uint8_t *in, uint8_t *&out, uint64_t len);
+
 private:
 	uint64_t get_subsample(int level, uint64_t offset) const;
 
@@ -117,6 +121,9 @@ private:
 
 	struct MipMapLevel mip_map_[ScaleStepCount];
 	uint64_t last_append_sample_;
+	uint64_t last_append_accumulator_;
+	uint64_t last_append_extra_;
+
 
 	friend struct LogicSegmentTest::Pow2;
 	friend struct LogicSegmentTest::Basic;

--- a/pv/data/logicsegment.hpp
+++ b/pv/data/logicsegment.hpp
@@ -124,7 +124,6 @@ private:
 	uint64_t last_append_accumulator_;
 	uint64_t last_append_extra_;
 
-
 	friend struct LogicSegmentTest::Pow2;
 	friend struct LogicSegmentTest::Basic;
 	friend struct LogicSegmentTest::LargeData;

--- a/pv/data/segment.cpp
+++ b/pv/data/segment.cpp
@@ -289,5 +289,13 @@ uint8_t* Segment::get_iterator_value(SegmentDataIterator* it)
 	return (it->chunk + it->chunk_offs);
 }
 
+uint64_t Segment::get_iterator_valid_length(SegmentDataIterator* it)
+{
+	assert(it->sample_index <= (sample_count_ - 1));
+
+	return ((chunk_size_ - it->chunk_offs) / unit_size_);
+}
+
+
 } // namespace data
 } // namespace pv

--- a/pv/data/segment.cpp
+++ b/pv/data/segment.cpp
@@ -296,6 +296,5 @@ uint64_t Segment::get_iterator_valid_length(SegmentDataIterator* it)
 	return ((chunk_size_ - it->chunk_offs) / unit_size_);
 }
 
-
 } // namespace data
 } // namespace pv

--- a/pv/data/segment.hpp
+++ b/pv/data/segment.hpp
@@ -90,6 +90,7 @@ protected:
 	void continue_sample_iteration(SegmentDataIterator* it, uint64_t increase);
 	void end_sample_iteration(SegmentDataIterator* it);
 	uint8_t* get_iterator_value(SegmentDataIterator* it);
+	uint64_t get_iterator_valid_length(SegmentDataIterator* it);
 
 	uint32_t segment_id_;
 	mutable recursive_mutex mutex_;


### PR DESCRIPTION
Makes use of the segment chunk size to process samples in contiguous blocks when possible.

Provide routines for downsampling with sample sizes of 1, 2, 4 & 8 bytes which the compiler can optimize.

These changes halve the time taken to display the 23MB ws2812b_neopixel24_4mhz_verylong.sr from
40 seconds to 18 seconds.