### PR TITLE
Ensure edge values alternate to fix 'fill high areas of logic signals'

### DIFF
--- a/pv/views/trace/logicsignal.cpp
+++ b/pv/views/trace/logicsignal.cpp
@@ -258,10 +258,11 @@ void LogicSignal::paint_mid(QPainter &p, ViewItemPaintParams &pp)
 
 		if (fill_high_areas) {
 			// Any edge terminates a high area
-			const int width = x - rising_edge_x;
-			if (rising_edge_seen && (width > 0)) {
-				high_rects.emplace_back(rising_edge_x, high_offset,
-					width, signal_height_);
+			if (rising_edge_seen) {
+				const int width = x - rising_edge_x;
+				if (width > 0)
+					high_rects.emplace_back(rising_edge_x, high_offset,
+						width, signal_height_);
 				rising_edge_seen = false;
 			}
 


### PR DESCRIPTION
When 'Fill high areas of logic signals' is enabled the display occasionally gets confused and seems to pseudo-randomly choose to fill areas which should all be 0's. In some cases get_subsampled_edges() indicates an edge is present where the two data values are the same and this seems to be partly to blame. This can happen because the edge detection was returning the last sample for the block instead of the sample that indicated the transition. If instead we force all edges to record alternate high/low values then the visual result seems more consistent.

I can't fully explain why this change works, maybe it is a side effect of a bug elsewhere.