### PR TITLE
Fix memory leak in DecoderMenu

### DIFF
--- a/pv/widgets/decodermenu.cpp
+++ b/pv/widgets/decodermenu.cpp
@@ -30,9 +30,9 @@ DecoderMenu::DecoderMenu(QWidget *parent, bool first_level_decoder) :
 	QMenu(parent),
 	mapper_(this)
 {
-	GSList *l = g_slist_sort(g_slist_copy(
+	GSList *li = g_slist_sort(g_slist_copy(
 		(GSList*)srd_decoder_list()), decoder_name_cmp);
-	for (; l; l = l->next) {
+	for (GSList *l = li; l; l = l->next) {
 		const srd_decoder *const d = (srd_decoder*)l->data;
 		assert(d);
 
@@ -46,7 +46,7 @@ DecoderMenu::DecoderMenu(QWidget *parent, bool first_level_decoder) :
 				&mapper_, SLOT(map()));
 		}
 	}
-	g_slist_free(l);
+	g_slist_free(li);
 
 	connect(&mapper_, SIGNAL(mapped(QObject*)),
 		this, SLOT(on_action(QObject*)));


### PR DESCRIPTION
```
==214004== 1,536 (16 direct, 1,520 indirect) bytes in 1 blocks are definitely lost in loss record 6,288 of 6,442
==214004==    at 0x4C2EE0B: malloc (vg_replace_malloc.c:299)
==214004==    by 0x67D8435: g_malloc (in /usr/lib64/libglib-2.0.so.0.5600.3)
==214004==    by 0x67F0056: g_slice_alloc (in /usr/lib64/libglib-2.0.so.0.5600.3)
==214004==    by 0x67F14FA: g_slist_copy_deep (in /usr/lib64/libglib-2.0.so.0.5600.3)
==214004==    by 0x5584FC: pv::widgets::DecoderMenu::DecoderMenu(QWidget*, bool) (decodermenu.cpp:33)
```