### PR TITLE
Fix clazy complaints about missing Q_EMIT and class qualifiers

### DIFF
--- a/pv/binding/device.cpp
+++ b/pv/binding/device.cpp
@@ -78,7 +78,7 @@ Device::Device(shared_ptr<sigrok::Configurable> configurable) :
 			return configurable_->config_get(key); };
 		const Property::Setter set = [&, key](Glib::VariantBase value) {
 			configurable_->config_set(key, value);
-			config_changed();
+			Q_EMIT config_changed();
 		};
 
 		switch (key->id()) {

--- a/pv/data/analog.cpp
+++ b/pv/data/analog.cpp
@@ -60,7 +60,7 @@ void Analog::clear()
 {
 	segments_.clear();
 
-	samples_cleared();
+	Q_EMIT samples_cleared();
 }
 
 double Analog::get_samplerate() const
@@ -84,12 +84,12 @@ uint64_t Analog::max_sample_count() const
 void Analog::notify_samples_added(QObject* segment, uint64_t start_sample,
 	uint64_t end_sample)
 {
-	samples_added(segment, start_sample, end_sample);
+	Q_EMIT samples_added(segment, start_sample, end_sample);
 }
 
 void Analog::notify_min_max_changed(float min, float max)
 {
-	min_max_changed(min, max);
+	Q_EMIT min_max_changed(min, max);
 }
 
 } // namespace data

--- a/pv/data/analogsegment.cpp
+++ b/pv/data/analogsegment.cpp
@@ -253,7 +253,7 @@ void AnalogSegment::append_payload_to_envelope_levels()
 
 	// Notify if the min or max value changed
 	if ((old_min_value != min_value_) || (old_max_value != max_value_))
-		owner_.min_max_changed(min_value_, max_value_);
+		Q_EMIT owner_.min_max_changed(min_value_, max_value_);
 }
 
 } // namespace data

--- a/pv/data/decodesignal.cpp
+++ b/pv/data/decodesignal.cpp
@@ -166,7 +166,7 @@ void DecodeSignal::reset_decode(bool shutting_down)
 		qDebug().nospace() << name() << ": Error cleared";
 	}
 
-	decode_reset();
+	Q_EMIT decode_reset();
 }
 
 void DecodeSignal::begin_decode()
@@ -338,7 +338,7 @@ void DecodeSignal::auto_assign_signals(const shared_ptr<Decoder> dec)
 		logic_mux_data_invalid_ = true;
 		stack_config_changed_ = true;
 		commit_decoder_channels();
-		channels_updated();
+		Q_EMIT channels_updated();
 	}
 }
 
@@ -352,7 +352,7 @@ void DecodeSignal::assign_signal(const uint16_t channel_id, const SignalBase *si
 
 	stack_config_changed_ = true;
 	commit_decoder_channels();
-	channels_updated();
+	Q_EMIT channels_updated();
 	begin_decode();
 }
 
@@ -370,7 +370,7 @@ void DecodeSignal::set_initial_pin_state(const uint16_t channel_id, const int in
 			ch.initial_pin_state = init_state;
 
 	stack_config_changed_ = true;
-	channels_updated();
+	Q_EMIT channels_updated();
 	begin_decode();
 }
 
@@ -622,7 +622,7 @@ void DecodeSignal::restore_settings(QSettings &settings)
 		}
 
 		settings.endGroup();
-		channels_updated();
+		Q_EMIT channels_updated();
 	}
 
 	// Restore channel mapping
@@ -789,7 +789,7 @@ void DecodeSignal::update_channel_list()
 
 	}
 
-	channels_updated();
+	Q_EMIT channels_updated();
 }
 
 void DecodeSignal::commit_decoder_channels()
@@ -1003,7 +1003,7 @@ void DecodeSignal::decode_data(
 
 		// Notify the frontend that we processed some data and
 		// possibly have new annotations as well
-		new_annotations();
+		Q_EMIT new_annotations();
 
 		if (decode_paused_) {
 			unique_lock<mutex> pause_wait_lock(decode_pause_mutex_);
@@ -1073,7 +1073,7 @@ void DecodeSignal::decode_proc()
 				terminate_srd_session();
 			} else {
 				// All segments have been processed
-				decode_finished();
+				Q_EMIT decode_finished();
 
 				// Wait for new input data or an interrupt was requested
 				unique_lock<mutex> input_wait_lock(input_mutex_);

--- a/pv/data/logic.cpp
+++ b/pv/data/logic.cpp
@@ -66,7 +66,7 @@ void Logic::clear()
 {
 	segments_.clear();
 
-	samples_cleared();
+	Q_EMIT samples_cleared();
 }
 
 double Logic::get_samplerate() const
@@ -90,7 +90,7 @@ uint64_t Logic::max_sample_count() const
 void Logic::notify_samples_added(QObject* segment, uint64_t start_sample,
 	uint64_t end_sample)
 {
-	samples_added(segment, start_sample, end_sample);
+	Q_EMIT samples_added(segment, start_sample, end_sample);
 }
 
 } // namespace data

--- a/pv/data/signalbase.cpp
+++ b/pv/data/signalbase.cpp
@@ -96,7 +96,7 @@ void SignalBase::set_name(QString name)
 
 	name_ = name;
 
-	name_changed(name);
+	Q_EMIT name_changed(name);
 }
 
 bool SignalBase::enabled() const
@@ -108,7 +108,7 @@ void SignalBase::set_enabled(bool value)
 {
 	if (channel_) {
 		channel_->set_enabled(value);
-		enabled_changed(value);
+		Q_EMIT enabled_changed(value);
 	}
 }
 
@@ -142,7 +142,7 @@ void SignalBase::set_color(QColor color)
 	bgcolor_ = color;
 	bgcolor_.setAlpha(ColorBGAlpha);
 
-	color_changed(color);
+	Q_EMIT color_changed(color);
 }
 
 QColor SignalBase::bgcolor() const
@@ -297,7 +297,7 @@ void SignalBase::set_conversion_type(ConversionType t)
 
 		// Discard converted data
 		converted_data_.reset();
-		samples_cleared();
+		Q_EMIT samples_cleared();
 	}
 
 	conversion_type_ = t;
@@ -311,7 +311,7 @@ void SignalBase::set_conversion_type(ConversionType t)
 
 	start_conversion();
 
-	conversion_type_changed(t);
+	Q_EMIT conversion_type_changed(t);
 }
 
 map<QString, QVariant> SignalBase::get_conversion_options() const
@@ -547,7 +547,7 @@ void SignalBase::convert_single_segment_range(AnalogSegment *asegment,
 					analog->get_logic_via_threshold(threshold, lsamples);
 
 				lsegment->append_payload(logic->data_pointer(), logic->data_length());
-				samples_added(lsegment->segment_id(), i, i + ConversionBlockSize);
+				Q_EMIT samples_added(lsegment->segment_id(), i, i + ConversionBlockSize);
 				i += ConversionBlockSize;
 			}
 
@@ -561,7 +561,7 @@ void SignalBase::convert_single_segment_range(AnalogSegment *asegment,
 			shared_ptr<sigrok::Logic> logic =
 				analog->get_logic_via_threshold(threshold, lsamples);
 			lsegment->append_payload(logic->data_pointer(), logic->data_length());
-			samples_added(lsegment->segment_id(), i, end_sample);
+			Q_EMIT samples_added(lsegment->segment_id(), i, end_sample);
 		}
 
 		if (conversion_type_ == A2LConversionBySchmittTrigger) {
@@ -580,7 +580,7 @@ void SignalBase::convert_single_segment_range(AnalogSegment *asegment,
 						&state, lsamples);
 
 				lsegment->append_payload(logic->data_pointer(), logic->data_length());
-				samples_added(lsegment->segment_id(), i, i + ConversionBlockSize);
+				Q_EMIT samples_added(lsegment->segment_id(), i, i + ConversionBlockSize);
 				i += ConversionBlockSize;
 			}
 
@@ -595,7 +595,7 @@ void SignalBase::convert_single_segment_range(AnalogSegment *asegment,
 				analog->get_logic_via_schmitt_trigger(lo_thr, hi_thr,
 					&state, lsamples);
 			lsegment->append_payload(logic->data_pointer(), logic->data_length());
-			samples_added(lsegment->segment_id(), i, end_sample);
+			Q_EMIT samples_added(lsegment->segment_id(), i, end_sample);
 		}
 
 		// If acquisition is ongoing, start-/endsample may have changed
@@ -719,7 +719,7 @@ void SignalBase::start_conversion(bool delayed_start)
 
 	if (converted_data_)
 		converted_data_->clear();
-	samples_cleared();
+	Q_EMIT samples_cleared();
 
 	conversion_interrupt_ = false;
 	conversion_thread_ = std::thread(
@@ -740,7 +740,7 @@ void SignalBase::on_samples_cleared()
 	if (converted_data_)
 		converted_data_->clear();
 
-	samples_cleared();
+	Q_EMIT samples_cleared();
 }
 
 void SignalBase::on_samples_added(QObject* segment, uint64_t start_sample,
@@ -758,7 +758,7 @@ void SignalBase::on_samples_added(QObject* segment, uint64_t start_sample,
 	}
 
 	data::Segment* s = qobject_cast<data::Segment*>(segment);
-	samples_added(s->segment_id(), start_sample, end_sample);
+	Q_EMIT samples_added(s->segment_id(), start_sample, end_sample);
 }
 
 void SignalBase::on_min_max_changed(float min, float max)
@@ -768,7 +768,7 @@ void SignalBase::on_min_max_changed(float min, float max)
 		(get_current_conversion_preset() == DynamicPreset))
 		start_conversion(true);
 
-	min_max_changed(min, max);
+	Q_EMIT min_max_changed(min, max);
 }
 
 void SignalBase::on_capture_state_changed(int state)

--- a/pv/data/signalbase.hpp
+++ b/pv/data/signalbase.hpp
@@ -305,7 +305,7 @@ Q_SIGNALS:
 
 	void color_changed(const QColor &color);
 
-	void conversion_type_changed(const ConversionType t);
+	void conversion_type_changed(const pv::data::SignalBase::ConversionType t);
 
 	void samples_cleared();
 

--- a/pv/logging.cpp
+++ b/pv/logging.cpp
@@ -145,7 +145,7 @@ out:
 	// If we're tearing down the program, sending out notifications to UI
 	// elements that can no longer function properly is a bad idea
 	if (!QApplication::closingDown())
-		logged_text(s);
+		Q_EMIT logged_text(s);
 }
 
 void Logging::log_pv(QtMsgType type, const QMessageLogContext &context, const QString &msg)

--- a/pv/mainwindow.hpp
+++ b/pv/mainwindow.hpp
@@ -113,10 +113,10 @@ private:
 
 private Q_SLOTS:
 	void on_add_view(const QString &title, views::ViewType type,
-		Session *session);
+		pv::Session *session);
 
 	void on_focus_changed();
-	void on_focused_session_changed(shared_ptr<Session> session);
+	void on_focused_session_changed(shared_ptr<pv::Session> session);
 
 	void on_new_session_clicked();
 	void on_run_stop_clicked();
@@ -125,7 +125,7 @@ private Q_SLOTS:
 	void on_session_name_changed();
 	void on_capture_state_changed(QObject *obj);
 
-	void on_new_view(Session *session);
+	void on_new_view(pv::Session *session);
 	void on_view_close_clicked();
 
 	void on_tab_changed(int index);

--- a/pv/session.cpp
+++ b/pv/session.cpp
@@ -145,7 +145,7 @@ void Session::set_name(QString name)
 
 	name_ = name;
 
-	name_changed();
+	Q_EMIT name_changed();
 }
 
 const list< shared_ptr<views::ViewBase> > Session::views() const
@@ -359,7 +359,7 @@ void Session::restore_settings(QSettings &settings)
 
 			if (i > 0) {
 				views::ViewType type = (views::ViewType)settings.value("type").toInt();
-				add_view(name_, type, this);
+				Q_EMIT add_view(name_, type, this);
 				views_.back()->restore_settings(settings);
 			} else
 				main_view_->restore_settings(settings);
@@ -395,7 +395,7 @@ void Session::set_device(shared_ptr<devices::Device> device)
 
 	// Revert name back to default name (e.g. "Session 1") as the data is gone
 	name_ = default_name_;
-	name_changed();
+	Q_EMIT name_changed();
 
 	// Remove all stored data and reset all views
 	for (shared_ptr<views::ViewBase> view : views_) {
@@ -418,7 +418,7 @@ void Session::set_device(shared_ptr<devices::Device> device)
 
 	logic_data_.reset();
 
-	signals_changed();
+	Q_EMIT signals_changed();
 
 	device_ = move(device);
 
@@ -438,7 +438,7 @@ void Session::set_device(shared_ptr<devices::Device> device)
 		update_signals();
 	}
 
-	device_changed();
+	Q_EMIT device_changed();
 }
 
 void Session::set_default_device()
@@ -606,7 +606,7 @@ void Session::start_capture(function<void (const QString)> error_handler)
 
 	if (hw_device) {
 		name_ = default_name_;
-		name_changed();
+		Q_EMIT name_changed();
 	}
 
 	// Begin the session
@@ -667,7 +667,7 @@ void Session::register_view(shared_ptr<views::ViewBase> view)
 		}
 	}
 
-	signals_changed();
+	Q_EMIT signals_changed();
 }
 
 void Session::deregister_view(shared_ptr<views::ViewBase> view)
@@ -767,7 +767,7 @@ shared_ptr<data::DecodeSignal> Session::add_decode_signal()
 		return nullptr;
 	}
 
-	signals_changed();
+	Q_EMIT signals_changed();
 
 	return signal;
 }
@@ -779,7 +779,7 @@ void Session::remove_decode_signal(shared_ptr<data::DecodeSignal> signal)
 	for (shared_ptr<views::ViewBase>& view : views_)
 		view->remove_decode_signal(signal);
 
-	signals_changed();
+	Q_EMIT signals_changed();
 }
 #endif
 
@@ -794,7 +794,7 @@ void Session::set_capture_state(capture_state state)
 	}
 
 	if (changed)
-		capture_state_changed(state);
+		Q_EMIT capture_state_changed(state);
 }
 
 void Session::update_signals()
@@ -929,7 +929,7 @@ void Session::update_signals()
 		}
 	}
 
-	signals_changed();
+	Q_EMIT signals_changed();
 }
 
 shared_ptr<data::SignalBase> Session::signalbase_from_channel(
@@ -1040,7 +1040,7 @@ void Session::signal_new_segment()
 
 	if (new_segment_id > highest_segment_id_) {
 		highest_segment_id_ = new_segment_id;
-		new_segment(highest_segment_id_);
+		Q_EMIT new_segment(highest_segment_id_);
 	}
 }
 
@@ -1062,7 +1062,7 @@ void Session::signal_segment_completed()
 	}
 
 	if (segment_id >= 0)
-		segment_completed(segment_id);
+		Q_EMIT segment_completed(segment_id);
 }
 
 void Session::feed_in_header()
@@ -1083,7 +1083,7 @@ void Session::feed_in_meta(shared_ptr<Meta> meta)
 		}
 	}
 
-	signals_changed();
+	Q_EMIT signals_changed();
 }
 
 void Session::feed_in_trigger()
@@ -1123,7 +1123,7 @@ void Session::feed_in_trigger()
 	// TODO Create timestamp from segment start time + segment's current sample count
 	util::Timestamp timestamp = sample_count / get_samplerate();
 	trigger_list_.emplace_back(segment_id, timestamp);
-	trigger_event(segment_id, timestamp);
+	Q_EMIT trigger_event(segment_id, timestamp);
 }
 
 void Session::feed_in_frame_begin()
@@ -1194,7 +1194,7 @@ void Session::feed_in_logic(shared_ptr<Logic> logic)
 
 	cur_logic_segment_->append_payload(logic);
 
-	data_received();
+	Q_EMIT data_received();
 }
 
 void Session::feed_in_analog(shared_ptr<Analog> analog)
@@ -1267,7 +1267,7 @@ void Session::feed_in_analog(shared_ptr<Analog> analog)
 		set_capture_state(Running);
 	}
 
-	data_received();
+	Q_EMIT data_received();
 }
 
 void Session::data_feed_in(shared_ptr<sigrok::Device> device,

--- a/pv/session.hpp
+++ b/pv/session.hpp
@@ -235,7 +235,7 @@ Q_SIGNALS:
 	void data_received();
 
 	void add_view(const QString &title, views::ViewType type,
-		Session *session);
+		pv::Session *session);
 
 public Q_SLOTS:
 	void on_data_saved();

--- a/pv/storesession.cpp
+++ b/pv/storesession.cpp
@@ -235,7 +235,7 @@ void StoreSession::store_proc(vector< shared_ptr<data::SignalBase> > achannel_li
 		min(asamples_per_block, lsamples_per_block);
 
 	while (!interrupt_ && sample_count_) {
-		progress_updated();
+		Q_EMIT progress_updated();
 
 		const uint64_t packet_len =
 			min((uint64_t)samples_per_block, sample_count_);
@@ -289,8 +289,8 @@ void StoreSession::store_proc(vector< shared_ptr<data::SignalBase> > achannel_li
 	// Zeroing the progress variables indicates completion
 	units_stored_ = unit_count_ = 0;
 
-	store_successful();
-	progress_updated();
+	Q_EMIT store_successful();
+	Q_EMIT progress_updated();
 
 	output_.reset();
 	output_stream_.close();

--- a/pv/toolbars/mainbar.cpp
+++ b/pv/toolbars/mainbar.cpp
@@ -752,7 +752,7 @@ void MainBar::on_config_changed()
 
 void MainBar::on_actionNewView_triggered()
 {
-	new_view(&session_);
+	Q_EMIT new_view(&session_);
 }
 
 void MainBar::on_actionOpen_triggered()

--- a/pv/toolbars/mainbar.hpp
+++ b/pv/toolbars/mainbar.hpp
@@ -151,7 +151,7 @@ protected:
 	bool eventFilter(QObject *watched, QEvent *event);
 
 Q_SIGNALS:
-	void new_view(Session *session);
+	void new_view(pv::Session *session);
 
 private:
 	QToolButton *open_button_, *save_button_;

--- a/pv/views/trace/standardbar.cpp
+++ b/pv/views/trace/standardbar.cpp
@@ -271,7 +271,7 @@ void StandardBar::on_segment_selected(int ui_segment_id)
 	if (view_->segment_display_mode() != Trace::ShowSingleSegmentOnly)
 		on_actionSDMSingle_triggered();
 
-	segment_selected(segment_id);
+	Q_EMIT segment_selected(segment_id);
 }
 
 void StandardBar::on_segment_display_mode_changed(int mode, bool segment_selectable)

--- a/pv/views/trace/view.cpp
+++ b/pv/views/trace/view.cpp
@@ -250,7 +250,7 @@ void View::reset_view_state()
 	suppress_zoom_to_fit_after_acq_ = false;
 
 	show_cursors_ = false;
-	cursor_state_changed(show_cursors_);
+	Q_EMIT cursor_state_changed(show_cursors_);
 	flags_.clear();
 
 	// Update the zoom state
@@ -472,7 +472,7 @@ void View::set_scale(double scale)
 {
 	if (scale_ != scale) {
 		scale_ = scale;
-		scale_changed();
+		Q_EMIT scale_changed();
 	}
 }
 
@@ -481,7 +481,7 @@ void View::set_offset(const pv::util::Timestamp& offset, bool force_update)
 	if ((offset_ != offset) || force_update) {
 		offset_ = offset;
 		ruler_offset_ = offset_ + ruler_shift_;
-		offset_changed();
+		Q_EMIT offset_changed();
 	}
 }
 
@@ -547,7 +547,7 @@ void View::set_tick_prefix(pv::util::SIPrefix tick_prefix)
 {
 	if (tick_prefix_ != tick_prefix) {
 		tick_prefix_ = tick_prefix;
-		tick_prefix_changed();
+		Q_EMIT tick_prefix_changed();
 	}
 }
 
@@ -560,7 +560,7 @@ void View::set_tick_precision(unsigned tick_precision)
 {
 	if (tick_precision_ != tick_precision) {
 		tick_precision_ = tick_precision;
-		tick_precision_changed();
+		Q_EMIT tick_precision_changed();
 	}
 }
 
@@ -578,7 +578,7 @@ void View::set_tick_period(const pv::util::Timestamp& tick_period)
 {
 	if (tick_period_ != tick_period) {
 		tick_period_ = tick_period;
-		tick_period_changed();
+		Q_EMIT tick_period_changed();
 	}
 }
 
@@ -591,7 +591,7 @@ void View::set_time_unit(pv::util::TimeUnit time_unit)
 {
 	if (time_unit_ != time_unit) {
 		time_unit_ = time_unit;
-		time_unit_changed();
+		Q_EMIT time_unit_changed();
 	}
 }
 
@@ -621,7 +621,7 @@ void View::set_current_segment(uint32_t segment_id)
 
 	viewport_->update();
 
-	segment_changed(segment_id);
+	Q_EMIT segment_changed(segment_id);
 }
 
 bool View::segment_is_selectable() const
@@ -677,7 +677,7 @@ void View::set_segment_display_mode(Trace::SegmentDisplayMode mode)
 
 	viewport_->update();
 
-	segment_display_mode_changed((int)mode, segment_selectable_);
+	Q_EMIT segment_display_mode_changed((int)mode, segment_selectable_);
 }
 
 void View::zoom(double steps)
@@ -695,10 +695,10 @@ void View::zoom_fit(bool gui_state)
 	// Act as one-shot when stopped, toggle along with the GUI otherwise
 	if (session_.get_capture_state() == Session::Stopped) {
 		always_zoom_to_fit_ = false;
-		always_zoom_to_fit_changed(false);
+		Q_EMIT always_zoom_to_fit_changed(false);
 	} else {
 		always_zoom_to_fit_ = gui_state;
-		always_zoom_to_fit_changed(gui_state);
+		Q_EMIT always_zoom_to_fit_changed(gui_state);
 	}
 
 	const pair<Timestamp, Timestamp> extents = get_time_extents();
@@ -724,12 +724,12 @@ void View::set_scale_offset(double scale, const Timestamp& offset)
 
 		if (sticky_scrolling_) {
 			sticky_scrolling_ = false;
-			sticky_scrolling_changed(false);
+			Q_EMIT sticky_scrolling_changed(false);
 		}
 
 		if (always_zoom_to_fit_) {
 			always_zoom_to_fit_ = false;
-			always_zoom_to_fit_changed(false);
+			Q_EMIT always_zoom_to_fit_changed(false);
 		}
 	}
 
@@ -814,7 +814,7 @@ bool View::cursors_shown() const
 void View::show_cursors(bool show)
 {
 	show_cursors_ = show;
-	cursor_state_changed(show);
+	Q_EMIT cursor_state_changed(show);
 	ruler_->update();
 	viewport_->update();
 }
@@ -1043,7 +1043,7 @@ void View::set_zoom(double scale, int offset)
 {
 	// Reset the "always zoom to fit" feature as the user changed the zoom
 	always_zoom_to_fit_ = false;
-	always_zoom_to_fit_changed(false);
+	Q_EMIT always_zoom_to_fit_changed(false);
 
 	const Timestamp cursor_offset = offset_ + scale_ * offset;
 	const Timestamp new_scale = max(min(Timestamp(scale), MaxScale), MinScale);
@@ -1431,7 +1431,7 @@ void View::update_hover_point()
 		r->hover_point_changed(hover_point_);
 
 	// Notify any other listeners
-	hover_point_changed(hover_widget_, hover_point_);
+	Q_EMIT hover_point_changed(hover_widget_, hover_point_);
 }
 
 void View::row_item_appearance_changed(bool label, bool content)
@@ -1489,7 +1489,7 @@ void View::h_scroll_value_changed(int value)
 	// during a running acquisition
 	if (sticky_scrolling_ && (session_.get_capture_state() == Session::Running)) {
 		sticky_scrolling_ = false;
-		sticky_scrolling_changed(false);
+		Q_EMIT sticky_scrolling_changed(false);
 	}
 
 	const int range = scrollarea_->horizontalScrollBar()->maximum();
@@ -1709,7 +1709,7 @@ void View::capture_state_updated(int state)
 		bool state = settings.value(GlobalSettings::Key_View_ZoomToFitDuringAcq).toBool();
 		if (is_main_view_ && state) {
 			always_zoom_to_fit_ = true;
-			always_zoom_to_fit_changed(always_zoom_to_fit_);
+			Q_EMIT always_zoom_to_fit_changed(always_zoom_to_fit_);
 		}
 
 		// Enable sticky scrolling if the setting is enabled
@@ -1730,7 +1730,7 @@ void View::capture_state_updated(int state)
 			// Perform a final zoom-to-fit before disabling
 			zoom_fit(always_zoom_to_fit_);
 			always_zoom_to_fit_ = false;
-			always_zoom_to_fit_changed(always_zoom_to_fit_);
+			Q_EMIT always_zoom_to_fit_changed(always_zoom_to_fit_);
 		}
 
 		bool zoom_to_fit_after_acq =

--- a/pv/views/trace/viewwidget.cpp
+++ b/pv/views/trace/viewwidget.cpp
@@ -190,7 +190,7 @@ void ViewWidget::mouse_left_press_event(QMouseEvent *event)
 	if (!item_dragged)
 		drag();
 
-	selection_changed();
+	Q_EMIT selection_changed();
 }
 
 void ViewWidget::mouse_left_release_event(QMouseEvent *event)

--- a/pv/widgets/colorbutton.cpp
+++ b/pv/widgets/colorbutton.cpp
@@ -108,13 +108,13 @@ void ColorButton::on_selected(int row, int col)
 	assert(popup_);
 
 	cur_color_ = popup_->well_array().cellBrush(row, col).color();
-	selected(cur_color_);
+	Q_EMIT selected(cur_color_);
 }
 
 void ColorButton::on_color_selected(const QColor& color)
 {
 	cur_color_ = color;
-	selected(cur_color_);
+	Q_EMIT selected(cur_color_);
 }
 
 void ColorButton::paintEvent(QPaintEvent *event)

--- a/pv/widgets/decodermenu.cpp
+++ b/pv/widgets/decodermenu.cpp
@@ -65,7 +65,7 @@ void DecoderMenu::on_action(QObject *action)
 		(srd_decoder*)((QAction*)action)->data().value<void*>();
 	assert(dec);
 
-	decoder_selected(dec);
+	Q_EMIT decoder_selected(dec);
 }
 
 }  // namespace widgets

--- a/pv/widgets/devicetoolbutton.cpp
+++ b/pv/widgets/devicetoolbutton.cpp
@@ -129,7 +129,7 @@ void DeviceToolButton::on_action(QObject *action)
 	setText(QString::fromStdString(
 		selected_device_->display_name(device_manager_)));
 
-	device_selected();
+	Q_EMIT device_selected();
 }
 
 void DeviceToolButton::on_menu_hovered(QAction *action)

--- a/pv/widgets/exportmenu.cpp
+++ b/pv/widgets/exportmenu.cpp
@@ -92,7 +92,7 @@ void ExportMenu::on_action(QObject *action)
 	if (iter == formats.cend())
 		return;
 
-	format_selected((*iter).second);
+	Q_EMIT format_selected((*iter).second);
 }
 
 }  // namespace widgets

--- a/pv/widgets/importmenu.cpp
+++ b/pv/widgets/importmenu.cpp
@@ -81,7 +81,7 @@ void ImportMenu::on_action(QObject *action)
 	if (iter == formats.cend())
 		return;
 
-	format_selected((*iter).second);
+	Q_EMIT format_selected((*iter).second);
 }
 
 }  // namespace widgets

--- a/pv/widgets/popup.cpp
+++ b/pv/widgets/popup.cpp
@@ -245,7 +245,7 @@ void Popup::reposition_widget()
 
 void Popup::closeEvent(QCloseEvent*)
 {
-	closed();
+	Q_EMIT closed();
 }
 
 void Popup::paintEvent(QPaintEvent*)

--- a/pv/widgets/timestampspinbox.cpp
+++ b/pv/widgets/timestampspinbox.cpp
@@ -87,7 +87,7 @@ void TimestampSpinBox::setValue(const pv::util::Timestamp& val)
 
 	value_ = val;
 	updateEdit();
-	valueChanged(value_);
+	Q_EMIT valueChanged(value_);
 }
 
 void TimestampSpinBox::on_editingFinished()

--- a/pv/widgets/wellarray.cpp
+++ b/pv/widgets/wellarray.cpp
@@ -220,7 +220,7 @@ void WellArray::setSelected(int row, int col)
     updateCell(oldRow, oldCol);
     updateCell(selRow, selCol);
     if (row >= 0)
-        selected(row, col);
+        Q_EMIT selected(row, col);
 }
 
 void WellArray::focusInEvent(QFocusEvent*)


### PR DESCRIPTION
I ran clazy and fixed up all complaints it made about missing Q_EMIT annotations and a few missing class qualifiers. The changes were pretty mechanical so if clazy got something wrong then I probably wouldn't have noticed. The code still compiles and runs OK for me.