### PR TITLE
Support recent libsigrok changes

### DIFF
--- a/pv/binding/device.cpp
+++ b/pv/binding/device.cpp
@@ -77,8 +77,9 @@ Device::Device(shared_ptr<sigrok::Configurable> configurable) :
 		const Property::Getter get = [&, key]() {
 			return configurable_->config_get(key); };
 		const Property::Setter set = [&, key](Glib::VariantBase value) {
-			configurable_->config_set(key, value);
-			config_changed();
+			if (configurable_->config_set(key, value) != 0)
+				if (configurable_->config_set(key, value) != 0)
+					config_changed();
 		};
 
 		switch (key->id()) {

--- a/pv/binding/device.cpp
+++ b/pv/binding/device.cpp
@@ -114,7 +114,7 @@ Device::Device(shared_ptr<sigrok::Configurable> configurable) :
 			bind_enum(name, "", key, capabilities, get, set, print_timebase);
 			break;
 
-		case SR_CONF_VDIV:
+		case SR_CONF_VSCALE:
 			bind_enum(name, "", key, capabilities, get, set, print_vdiv);
 			break;
 

--- a/pv/session.cpp
+++ b/pv/session.cpp
@@ -932,6 +932,7 @@ void Session::update_signals()
 						break;
 
 					case SR_CHANNEL_ANALOG:
+					case SR_CHANNEL_FFT:
 					{
 						if (!signalbase) {
 							signalbase = make_shared<data::SignalBase>(channel,

--- a/pv/toolbars/mainbar.cpp
+++ b/pv/toolbars/mainbar.cpp
@@ -521,6 +521,7 @@ void MainBar::update_device_config_widgets()
 
 void MainBar::commit_sample_rate()
 {
+	int result;
 	uint64_t sample_rate = 0;
 
 	const shared_ptr<devices::Device> device = device_selector_.selected_device();
@@ -532,9 +533,10 @@ void MainBar::commit_sample_rate()
 	sample_rate = sample_rate_.value();
 
 	try {
-		sr_dev->config_set(ConfigKey::SAMPLERATE,
+		result = sr_dev->config_set(ConfigKey::SAMPLERATE,
 			Glib::Variant<guint64>::create(sample_rate));
-		update_sample_rate_selector();
+		if (result == SR_OK)
+			update_sample_rate_selector();
 	} catch (Error& error) {
 		qDebug() << tr("Failed to configure samplerate:") << error.what();
 		return;
@@ -548,6 +550,7 @@ void MainBar::commit_sample_rate()
 
 void MainBar::commit_sample_count()
 {
+	int result;
 	uint64_t sample_count = 0;
 
 	const shared_ptr<devices::Device> device = device_selector_.selected_device();
@@ -559,9 +562,10 @@ void MainBar::commit_sample_count()
 	sample_count = sample_count_.value();
 	if (sample_count_supported_) {
 		try {
-			sr_dev->config_set(ConfigKey::LIMIT_SAMPLES,
+			result = sr_dev->config_set(ConfigKey::LIMIT_SAMPLES,
 				Glib::Variant<guint64>::create(sample_count));
-			update_sample_count_selector();
+			if (result == SR_OK)
+				update_sample_count_selector();
 		} catch (Error& error) {
 			qDebug() << tr("Failed to configure sample count:") << error.what();
 			return;

--- a/pv/toolbars/mainbar.cpp
+++ b/pv/toolbars/mainbar.cpp
@@ -531,6 +531,8 @@ void MainBar::commit_sample_rate()
 	const shared_ptr<sigrok::Device> sr_dev = device->device();
 
 	sample_rate = sample_rate_.value();
+	if (sample_rate == 0)
+		return;
 
 	try {
 		result = sr_dev->config_set(ConfigKey::SAMPLERATE,


### PR DESCRIPTION
**1. The vertical scale setting is improperly named "vdiv" and as
    such it creates a great deal of confusion especially in new
    users and developers because it is easily mistaken with
    "num_vdiv" which is the number of vertical divisions !**

This pulseview patch is required by a recent libsigrok change:

https://github.com/sigrokproject/libsigrok/pull/17/commits/fc685341b2a32708f9e098e57a51d6bde894c6f6?
---
 pv/binding/device.cpp |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

------------------------------------------------------------------------------------------------------------------------------------

**2. Initial support for the FFT functionality recently introduced
    in libsigrok**

This pulseview patch is required by a recent libsigrok change:

https://github.com/sigrokproject/libsigrok/pull/17/commits/8d6d70eac5fad6b4e4f99378ea04baf921b707b7?
---
pv/session.cpp |    1 +
1 file changed, 1 insertion(+)

------------------------------------------------------------------------------------------------------------------------------------

**3. Do not crash on SCPI commands failure during config_set() but retry**

This pulseview patch needs the following recent libsigrok change:

https://github.com/sigrokproject/libsigrok/pull/17/commits/ed02b51299563e788deb6c9c01dc1baafa3b5e59?
---
 pv/binding/device.cpp   |    5 +++--
 pv/toolbars/mainbar.cpp |   12 ++++++++----
 2 files changed, 11 insertions(+), 6 deletions(-)

------------------------------------------------------------------------------------------------------------------------------------

**4. Do not attempt to set the Sample Rate to zero**

---
 pv/toolbars/mainbar.cpp |    2 ++
 1 file changed, 2 insertions(+)