### PR TITLE
Add -s / --settings parameter to load a session setup file

### DIFF
--- a/doc/pulseview.1
+++ b/doc/pulseview.1
@@ -64,6 +64,10 @@ file.
 .BR "\-I, \-\-input\-format " <format>
 Specifies the format of the input file to be loaded.
 .TP
+.BR "\-s, \-\-settings " <filename>
+Load PulseView session setup to use with the input file. The setup file must be
+in the "PulseView session setup" format (.pvs).
+.TP
 .BR "\-c, \-\-clean"
 Prevents the previously used sessions to be restored from settings storage.
 This is useful if you want only a single session with the file given on the

--- a/main.cpp
+++ b/main.cpp
@@ -159,6 +159,7 @@ void usage()
 		"  -d, --driver                    Specify the device driver to use\n"
 		"  -D, --dont-scan                 Don't auto-scan for devices, use -d spec only\n"
 		"  -i, --input-file                Load input from file\n"
+		"  -s, --settings                  Load PulseView session setup from file\n"
 		"  -I, --input-format              Input format\n"
 		"  -c, --clean                     Don't restore previous sessions on startup\n"
 		"\n", PV_BIN_NAME);
@@ -168,7 +169,7 @@ int main(int argc, char *argv[])
 {
 	int ret = 0;
 	shared_ptr<sigrok::Context> context;
-	string open_file_format, driver;
+	string open_file_format, open_setup_file, driver;
 	vector<string> open_files;
 	bool restore_sessions = true;
 	bool do_scan = true;
@@ -199,6 +200,7 @@ int main(int argc, char *argv[])
 			{"driver", required_argument, nullptr, 'd'},
 			{"dont-scan", no_argument, nullptr, 'D'},
 			{"input-file", required_argument, nullptr, 'i'},
+			{"settings", required_argument, nullptr, 's'},
 			{"input-format", required_argument, nullptr, 'I'},
 			{"clean", no_argument, nullptr, 'c'},
 			{"log-to-stdout", no_argument, nullptr, 's'},
@@ -206,7 +208,7 @@ int main(int argc, char *argv[])
 		};
 
 		const int c = getopt_long(argc, argv,
-			"h?VDcl:d:i:I:", long_options, nullptr);
+			"h?VDcl:d:i:s:I:", long_options, nullptr);
 		if (c == -1)
 			break;
 
@@ -251,6 +253,10 @@ int main(int argc, char *argv[])
 
 		case 'i':
 			open_files.emplace_back(optarg);
+			break;
+
+		case 's':
+			open_setup_file = optarg;
 			break;
 
 		case 'I':
@@ -334,7 +340,8 @@ int main(int argc, char *argv[])
 				w.add_default_session();
 			else
 				for (string& open_file : open_files)
-					w.add_session_with_file(open_file, open_file_format);
+					w.add_session_with_file(open_file, open_file_format,
+						open_setup_file);
 
 #ifdef ENABLE_SIGNALS
 			if (SignalHandler::prepare_signals()) {

--- a/manual/cli.txt
+++ b/manual/cli.txt
@@ -23,6 +23,14 @@ Example:
 
 	pulseview -i data.csv -I csv:samplerate=3000000
 
+If you previously saved a PulseView session setup alongside your input file, PulseView will
+automatically load those settings so long as the setup file (.pvs) has the same base name
+as your input file.
+You can also manually specify a PulseView session setup file to load with -s / --settings.
+Example:
+
+	pulseview -s settings.pvs data.sr
+
 The remaining parameters are mostly for debug purposes:
 
 	-V / --version		Shows the release version

--- a/pv/mainwindow.cpp
+++ b/pv/mainwindow.cpp
@@ -399,10 +399,13 @@ void MainWindow::remove_session(shared_ptr<Session> session)
 }
 
 void MainWindow::add_session_with_file(string open_file_name,
-	string open_file_format)
+	string open_file_format,
+	string open_setup_file_name)
 {
 	shared_ptr<Session> session = add_session();
-	session->load_init_file(open_file_name, open_file_format);
+	session->load_init_file(open_file_name,
+		open_file_format,
+		open_setup_file_name);
 }
 
 void MainWindow::add_default_session()

--- a/pv/mainwindow.hpp
+++ b/pv/mainwindow.hpp
@@ -92,7 +92,9 @@ public:
 
 	void remove_session(shared_ptr<Session> session);
 
-	void add_session_with_file(string open_file_name, string open_file_format);
+	void add_session_with_file(string open_file_name,
+		string open_file_format,
+		string open_setup_file_name);
 
 	void add_default_session();
 

--- a/pv/session.cpp
+++ b/pv/session.cpp
@@ -588,7 +588,7 @@ void Session::load_file(QString file_name,
 	}
 
 	// Default the setup filename with a .pvs extension if none is provided
-	if (setup_file_name.isEmpty() || setup_file_name.isNull()) {
+	if (setup_file_name.isEmpty()) {
 		setup_file_name = file_name;
 		setup_file_name.truncate(setup_file_name.lastIndexOf('.'));
 		setup_file_name.append(".pvs");

--- a/pv/session.cpp
+++ b/pv/session.cpp
@@ -525,7 +525,9 @@ Session::input_format_options(vector<string> user_spec,
 	return result;
 }
 
-void Session::load_init_file(const string &file_name, const string &format)
+void Session::load_init_file(const string &file_name,
+	const string &format,
+	const string &setup_file_name)
 {
 	shared_ptr<InputFormat> input_format;
 	map<string, Glib::VariantBase> input_opts;
@@ -549,10 +551,13 @@ void Session::load_init_file(const string &file_name, const string &format)
 			input_format->options());
 	}
 
-	load_file(QString::fromStdString(file_name), input_format, input_opts);
+	load_file(QString::fromStdString(file_name),
+		QString::fromStdString(setup_file_name),
+		input_format, input_opts);
 }
 
 void Session::load_file(QString file_name,
+	QString setup_file_name,
 	shared_ptr<sigrok::InputFormat> format,
 	const map<string, Glib::VariantBase> &options)
 {
@@ -582,10 +587,13 @@ void Session::load_file(QString file_name,
 		return;
 	}
 
+	// Default the setup filename with a .pvs extension if none is provided
+	if (setup_file_name.isEmpty() || setup_file_name.isNull()) {
+		setup_file_name = file_name;
+		setup_file_name.truncate(setup_file_name.lastIndexOf('.'));
+		setup_file_name.append(".pvs");
+	}
 	// Auto-load the setup if one exists
-	QString setup_file_name = file_name;
-	setup_file_name.truncate(setup_file_name.lastIndexOf('.'));
-	setup_file_name.append(".pvs");
 	if (QFileInfo::exists(setup_file_name) && QFileInfo(setup_file_name).isReadable()) {
 		QSettings settings_storage(setup_file_name, QSettings::IniFormat);
 		restore_setup(settings_storage);

--- a/pv/session.hpp
+++ b/pv/session.hpp
@@ -171,9 +171,12 @@ public:
 
 	void set_default_device();
 
-	void load_init_file(const string &file_name, const string &format);
+	void load_init_file(const string &file_name,
+		const string &format,
+		const string &setup_file_name);
 
 	void load_file(QString file_name,
+		QString setup_file_name = nullptr,
 		shared_ptr<sigrok::InputFormat> format = nullptr,
 		const map<string, Glib::VariantBase> &options =
 			map<string, Glib::VariantBase>());

--- a/pv/toolbars/mainbar.cpp
+++ b/pv/toolbars/mainbar.cpp
@@ -705,7 +705,7 @@ void MainBar::import_file(shared_ptr<InputFormat> format)
 		options = dlg.options();
 	}
 
-	session_.load_file(file_name, format, options);
+	session_.load_file(file_name, nullptr, format, options);
 
 	const QString abs_path = QFileInfo(file_name).absolutePath();
 	settings.setValue(SettingOpenDirectory, abs_path);


### PR DESCRIPTION
This adds a `-s` / `--settings` command-line parameter to manually load a specific PulseView session setup file at startup. This is useful when opening multiple sessions captured with sigrok-cli that all share the same decoder settings.

Sample usage:

    pulseview -s i2c-bus.pvs trace1.sr trace2.sr trace3.sr
