### PR TITLE
Add shortcuts to + and - buttons for zooming in and out horizontally

### DIFF
--- a/pv/mainwindow.cpp
+++ b/pv/mainwindow.cpp
@@ -511,6 +511,12 @@ void MainWindow::setup_ui()
 	view_colored_bg_shortcut_ = new QShortcut(QKeySequence(Qt::Key_B), this, SLOT(on_view_colored_bg_shortcut()));
 	view_colored_bg_shortcut_->setAutoRepeat(false);
 
+	zoom_in_shortcut_ = new QShortcut(QKeySequence(Qt::Key_Plus), this, SLOT(on_zoom_in_shortcut_triggered()));
+	zoom_in_shortcut_->setAutoRepeat(false);
+
+	zoom_out_shortcut_ = new QShortcut(QKeySequence(Qt::Key_Minus), this, SLOT(on_zoom_out_shortcut_triggered()));
+	zoom_out_shortcut_->setAutoRepeat(false);
+
 	// Set up the tab area
 	new_session_button_ = new QToolButton();
 	new_session_button_->setIcon(QIcon::fromTheme("document-new",
@@ -599,6 +605,19 @@ void MainWindow::restore_ui_settings()
 		resize(1000, 720);
 
 	settings.endGroup();
+}
+
+void MainWindow::zoom_current_view(double steps)
+{
+	shared_ptr<Session> session = get_tab_session(session_selector_.currentIndex());
+
+	if (!session)
+		return;
+
+	shared_ptr<views::ViewBase> v = session.get()->main_view();
+	views::trace::View *tv =
+		qobject_cast<views::trace::View*>(v.get());
+	tv->zoom(steps);
 }
 
 shared_ptr<Session> MainWindow::get_tab_session(int index) const
@@ -947,6 +966,16 @@ void MainWindow::on_settingViewShowAnalogMinorGrid_changed(const QVariant new_va
 		if (view)
 			view->enable_show_analog_minor_grid(state);
 	}
+}
+
+void MainWindow::on_zoom_out_shortcut_triggered()
+{
+	zoom_current_view(-1);
+}
+
+void MainWindow::on_zoom_in_shortcut_triggered()
+{
+	zoom_current_view(1);
 }
 
 void MainWindow::on_close_current_tab()

--- a/pv/mainwindow.hpp
+++ b/pv/mainwindow.hpp
@@ -108,6 +108,8 @@ private:
 	void save_ui_settings();
 	void restore_ui_settings();
 
+	void zoom_current_view(double steps);
+
 	shared_ptr<Session> get_tab_session(int index) const;
 
 	void closeEvent(QCloseEvent *event);
@@ -148,6 +150,9 @@ private Q_SLOTS:
 	void on_settingViewShowSamplingPoints_changed(const QVariant new_value);
 	void on_settingViewShowAnalogMinorGrid_changed(const QVariant new_value);
 
+	void on_zoom_out_shortcut_triggered();
+	void on_zoom_in_shortcut_triggered();
+
 	void on_close_current_tab();
 
 private:
@@ -177,6 +182,8 @@ private:
 	QShortcut *run_stop_shortcut_;
 	QShortcut *close_application_shortcut_;
 	QShortcut *close_current_tab_shortcut_;
+	QShortcut *zoom_in_shortcut_;
+	QShortcut *zoom_out_shortcut_;
 };
 
 } // namespace pv


### PR DESCRIPTION
Added shortcuts to the + and - buttons for zooming in and out horizontally. I am also planning to add left-right and home end shortcuts as well. 