### PR TITLE
Miscellaneous ruler improvements

### DIFF
--- a/pv/util.cpp
+++ b/pv/util.cpp
@@ -138,8 +138,9 @@ QString format_time_si(const Timestamp& v, SIPrefix prefix,
 	QTextStream ts(&s);
 	if (sign && !v.is_zero())
 		ts << forcesign;
-	ts << qSetRealNumberPrecision(precision) << (v * multiplier) << ' '
-		<< prefix << unit;
+	ts << qSetRealNumberPrecision(precision) << (v * multiplier);
+	if (!unit.isNull())
+		ts << ' ' << prefix << unit;
 
 	return s;
 }

--- a/pv/views/trace/cursor.cpp
+++ b/pv/views/trace/cursor.cpp
@@ -59,7 +59,8 @@ QString Cursor::get_text() const
 	const pv::util::Timestamp& diff = abs(time_ - other->time_);
 
 	return Ruler::format_time_with_distance(
-		diff, time_, view_.tick_prefix(), view_.time_unit(), view_.tick_precision());
+		diff, view_.absolute_to_ruler_time(time_),
+        view_.tick_prefix(), view_.time_unit(), view_.tick_precision());
 }
 
 QRectF Cursor::label_rect(const QRectF &rect) const

--- a/pv/views/trace/cursorpair.cpp
+++ b/pv/views/trace/cursorpair.cpp
@@ -84,9 +84,22 @@ void CursorPair::set_time(const pv::util::Timestamp& time)
 	second_->set_time(time + delta);
 }
 
+const pv::util::Timestamp CursorPair::time() const
+{
+	return (first_->time() + second_->time()) / 2.0f;
+}
+
 float CursorPair::get_x() const
 {
 	return (first_->get_x() + second_->get_x()) / 2.0f;
+}
+
+const pv::util::Timestamp CursorPair::delta(const pv::util::Timestamp& other) const
+{
+	if (other < second_->time())
+		return other - first_->time();
+	else
+		return other - second_->time();
 }
 
 QPoint CursorPair::drag_point(const QRect &rect) const

--- a/pv/views/trace/cursorpair.hpp
+++ b/pv/views/trace/cursorpair.hpp
@@ -76,7 +76,11 @@ public:
 	 */
 	void set_time(const pv::util::Timestamp& time) override;
 
+	virtual const pv::util::Timestamp time() const override;
+
 	float get_x() const override;
+
+	virtual const pv::util::Timestamp delta(const pv::util::Timestamp& other) const override;
 
 	QPoint drag_point(const QRect &rect) const override;
 

--- a/pv/views/trace/cursorpair.hpp
+++ b/pv/views/trace/cursorpair.hpp
@@ -102,7 +102,8 @@ public:
 	/**
 	 * Constructs the string to display.
 	 */
-	QString format_string();
+	QString format_string(qreal max_width = 0, std::function<qreal(const QString&)> query_size
+			= [](const QString& s) -> qreal { Q_UNUSED(s); return 0; });
 
 	pair<float, float> get_cursor_offsets() const;
 

--- a/pv/views/trace/flag.hpp
+++ b/pv/views/trace/flag.hpp
@@ -73,6 +73,8 @@ public:
 
 	void delete_pressed();
 
+	QRectF label_rect(const QRectF &rect) const override;
+
 private Q_SLOTS:
 	void on_delete();
 

--- a/pv/views/trace/marginwidget.cpp
+++ b/pv/views/trace/marginwidget.cpp
@@ -76,6 +76,8 @@ void MarginWidget::keyPressEvent(QKeyEvent *event)
 			if (i->selected())
 				i->delete_pressed();
 	}
+
+    ViewWidget::keyPressEvent(event);
 }
 
 } // namespace trace

--- a/pv/views/trace/ruler.cpp
+++ b/pv/views/trace/ruler.cpp
@@ -172,6 +172,34 @@ vector< shared_ptr<ViewItem> > Ruler::items()
 		time_items.begin(), time_items.end());
 }
 
+void Ruler::item_hover(const shared_ptr<ViewItem> &item, QPoint pos)
+{
+	Q_UNUSED(pos);
+	hover_item_ = dynamic_pointer_cast<TimeItem>(item);
+}
+
+shared_ptr<TimeItem> Ruler::get_reference_item()
+{
+	if (mouse_modifiers_ & Qt::ShiftModifier)
+		return nullptr;
+
+	if (hover_item_ != nullptr)
+		return hover_item_;
+
+	shared_ptr<TimeItem> found(nullptr);
+	const vector< shared_ptr<TimeItem> > items(view_.time_items());
+	for (auto i = items.rbegin(); i != items.rend(); i++) {
+		if ((*i)->enabled() && (*i)->selected()) {
+			if (found == nullptr)
+				found = *i;
+			else
+				return nullptr; // Return null if multiple items are selected
+		}
+	}
+
+	return found;
+}
+
 shared_ptr<ViewItem> Ruler::get_mouse_over_item(const QPoint &pt)
 {
 	const vector< shared_ptr<TimeItem> > items(view_.time_items());
@@ -183,7 +211,7 @@ shared_ptr<ViewItem> Ruler::get_mouse_over_item(const QPoint &pt)
 
 void Ruler::mouseDoubleClickEvent(QMouseEvent *event)
 {
-	view_.add_flag(get_absolute_time_from_x_pos(event->x()));
+	hover_item_ = view_.add_flag(get_absolute_time_from_x_pos(event->x()));
 }
 
 void Ruler::paintEvent(QPaintEvent*)
@@ -336,7 +364,7 @@ void Ruler::invalidate_tick_position_cache()
 
 void Ruler::on_createMarker()
 {
-	view_.add_flag(get_absolute_time_from_x_pos(mouse_down_point_.x()));
+	hover_item_ = view_.add_flag(get_absolute_time_from_x_pos(mouse_down_point_.x()));
 }
 
 void Ruler::on_setZeroPosition()

--- a/pv/views/trace/ruler.cpp
+++ b/pv/views/trace/ruler.cpp
@@ -183,7 +183,7 @@ shared_ptr<ViewItem> Ruler::get_mouse_over_item(const QPoint &pt)
 
 void Ruler::mouseDoubleClickEvent(QMouseEvent *event)
 {
-	view_.add_flag(get_ruler_time_from_x_pos(event->x()));
+	view_.add_flag(get_absolute_time_from_x_pos(event->x()));
 }
 
 void Ruler::paintEvent(QPaintEvent*)

--- a/pv/views/trace/ruler.cpp
+++ b/pv/views/trace/ruler.cpp
@@ -88,7 +88,8 @@ QString Ruler::format_time_with_distance(
 	pv::util::SIPrefix prefix,
 	pv::util::TimeUnit unit,
 	unsigned precision,
-	bool sign)
+	bool sign,
+	bool show_unit)
 {
 	const unsigned limit = 60;
 
@@ -97,7 +98,7 @@ QString Ruler::format_time_with_distance(
 
 	// If we have to use samples then we have no alternative formats
 	if (unit == pv::util::TimeUnit::Samples)
-		return pv::util::format_time_si_adjusted(t, prefix, precision, "sa", sign);
+		return pv::util::format_time_si_adjusted(t, prefix, precision, show_unit ? "sa" : NULL, sign);
 
 	// View zoomed way out -> low precision (0), big distance (>=60s)
 	// -> DD:HH:MM
@@ -109,7 +110,7 @@ QString Ruler::format_time_with_distance(
 	// View zoomed way in -> high precision (>3), low step size (<1s)
 	// -> HH:MM:SS.mmm... or xxxx (si unit) if less than limit seconds
 	if (abs(t) < limit)
-		return pv::util::format_time_si_adjusted(t, prefix, precision, "s", sign);
+		return pv::util::format_time_si_adjusted(t, prefix, precision, show_unit ? "s" : NULL, sign);
 	else
 		return pv::util::format_time_minutes(t, precision, sign);
 }

--- a/pv/views/trace/ruler.hpp
+++ b/pv/views/trace/ruler.hpp
@@ -115,7 +115,8 @@ public:
 		pv::util::SIPrefix prefix = pv::util::SIPrefix::unspecified,
 		pv::util::TimeUnit unit = pv::util::TimeUnit::Time,
 		unsigned precision = 0,
-		bool sign = true);
+		bool sign = true,
+		bool show_unit = true);
 
 	pv::util::Timestamp get_absolute_time_from_x_pos(uint32_t x) const;
 	pv::util::Timestamp get_ruler_time_from_x_pos(uint32_t x) const;

--- a/pv/views/trace/ruler.hpp
+++ b/pv/views/trace/ruler.hpp
@@ -121,9 +121,12 @@ public:
 	pv::util::Timestamp get_absolute_time_from_x_pos(uint32_t x) const;
 	pv::util::Timestamp get_ruler_time_from_x_pos(uint32_t x) const;
 
+	shared_ptr<TimeItem> get_reference_item();
+
 protected:
 	virtual void contextMenuEvent(QContextMenuEvent *event) override;
 	void resizeEvent(QResizeEvent*) override;
+	virtual void item_hover(const shared_ptr<ViewItem> &item, QPoint pos) override;
 
 private:
 	/**
@@ -187,6 +190,8 @@ private:
 	 * every redraw. Set by 'paintEvent()' when needed.
 	 */
 	boost::optional<TickPositions> tick_position_cache_;
+
+	shared_ptr<TimeItem> hover_item_;
 
 	uint32_t context_menu_x_pos_;
 };

--- a/pv/views/trace/timeitem.hpp
+++ b/pv/views/trace/timeitem.hpp
@@ -49,7 +49,11 @@ public:
 	 */
 	virtual void set_time(const pv::util::Timestamp& time) = 0;
 
+	virtual const pv::util::Timestamp time() const = 0;
+
 	virtual float get_x() const = 0;
+
+	virtual const pv::util::Timestamp delta(const pv::util::Timestamp& other) const = 0;
 
 	/**
 	 * Drags the item to a delta relative to the drag point.

--- a/pv/views/trace/timemarker.cpp
+++ b/pv/views/trace/timemarker.cpp
@@ -53,7 +53,7 @@ TimeMarker::TimeMarker(
 {
 }
 
-const pv::util::Timestamp& TimeMarker::time() const
+const pv::util::Timestamp TimeMarker::time() const
 {
 	return time_;
 }
@@ -74,6 +74,11 @@ float TimeMarker::get_x() const
 {
 	// Use roundf() from cmath, std::roundf() causes Android issues (see #945).
 	return roundf(((time_ - view_.offset()) / view_.scale()).convert_to<float>()) + 0.5f;
+}
+
+const pv::util::Timestamp TimeMarker::delta(const pv::util::Timestamp& other) const
+{
+	return other - time_;
 }
 
 QPoint TimeMarker::drag_point(const QRect &rect) const

--- a/pv/views/trace/timemarker.cpp
+++ b/pv/views/trace/timemarker.cpp
@@ -65,7 +65,7 @@ void TimeMarker::set_time(const pv::util::Timestamp& time)
 
 	if (value_widget_) {
 		updating_value_widget_ = true;
-		value_widget_->setValue(time);
+		value_widget_->setValue(view_.absolute_to_ruler_time(time));
 		updating_value_widget_ = false;
 	}
 
@@ -179,7 +179,7 @@ pv::widgets::Popup* TimeMarker::create_popup(QWidget *parent)
 	popup->setLayout(form);
 
 	value_widget_ = new pv::widgets::TimestampSpinBox(parent);
-	value_widget_->setValue(time_);
+	value_widget_->setValue(view_.absolute_to_ruler_time(time_));
 
 	connect(value_widget_, SIGNAL(valueChanged(const pv::util::Timestamp&)),
 		this, SLOT(on_value_changed(const pv::util::Timestamp&)));
@@ -192,7 +192,7 @@ pv::widgets::Popup* TimeMarker::create_popup(QWidget *parent)
 void TimeMarker::on_value_changed(const pv::util::Timestamp& value)
 {
 	if (!updating_value_widget_)
-		set_time(value);
+		set_time(view_.ruler_to_absolute_time(value));
 }
 
 } // namespace trace

--- a/pv/views/trace/timemarker.cpp
+++ b/pv/views/trace/timemarker.cpp
@@ -49,8 +49,7 @@ TimeMarker::TimeMarker(
 	color_(color),
 	time_(time),
 	value_action_(nullptr),
-	value_widget_(nullptr),
-	updating_value_widget_(false)
+	value_widget_(nullptr)
 {
 }
 
@@ -64,9 +63,8 @@ void TimeMarker::set_time(const pv::util::Timestamp& time)
 	time_ = time;
 
 	if (value_widget_) {
-		updating_value_widget_ = true;
+		QSignalBlocker blocker(value_widget_);
 		value_widget_->setValue(view_.absolute_to_ruler_time(time));
-		updating_value_widget_ = false;
 	}
 
 	view_.time_item_appearance_changed(true, true);
@@ -191,8 +189,7 @@ pv::widgets::Popup* TimeMarker::create_popup(QWidget *parent)
 
 void TimeMarker::on_value_changed(const pv::util::Timestamp& value)
 {
-	if (!updating_value_widget_)
-		set_time(view_.ruler_to_absolute_time(value));
+	set_time(view_.ruler_to_absolute_time(value));
 }
 
 } // namespace trace

--- a/pv/views/trace/timemarker.hpp
+++ b/pv/views/trace/timemarker.hpp
@@ -65,7 +65,7 @@ public:
 	/**
 	 * Gets the time of the marker.
 	 */
-	const pv::util::Timestamp& time() const;
+	virtual const pv::util::Timestamp time() const override;
 
 	/**
 	 * Sets the time of the marker.
@@ -73,6 +73,8 @@ public:
 	void set_time(const pv::util::Timestamp& time) override;
 
 	float get_x() const override;
+
+	virtual const pv::util::Timestamp delta(const pv::util::Timestamp& other) const override;
 
 	/**
 	 * Gets the arrow-tip point of the time marker.

--- a/pv/views/trace/timemarker.hpp
+++ b/pv/views/trace/timemarker.hpp
@@ -128,7 +128,6 @@ protected:
 
 	QWidgetAction *value_action_;
 	pv::widgets::TimestampSpinBox *value_widget_;
-	bool updating_value_widget_;
 };
 
 } // namespace trace

--- a/pv/views/trace/triggermarker.cpp
+++ b/pv/views/trace/triggermarker.cpp
@@ -52,13 +52,22 @@ bool TriggerMarker::is_draggable(QPoint pos) const
 void TriggerMarker::set_time(const pv::util::Timestamp& time)
 {
 	time_ = time;
-
 	view_.time_item_appearance_changed(true, true);
+}
+
+const pv::util::Timestamp TriggerMarker::time() const
+{
+	return time_;
 }
 
 float TriggerMarker::get_x() const
 {
 	return ((time_ - view_.offset()) / view_.scale()).convert_to<float>();
+}
+
+const pv::util::Timestamp TriggerMarker::delta(const pv::util::Timestamp& other) const
+{
+	return other - time_;
 }
 
 QPoint TriggerMarker::drag_point(const QRect &rect) const

--- a/pv/views/trace/triggermarker.hpp
+++ b/pv/views/trace/triggermarker.hpp
@@ -67,7 +67,11 @@ public:
 	 */
 	void set_time(const pv::util::Timestamp& time) override;
 
+	virtual const pv::util::Timestamp time() const override;
+
 	float get_x() const override;
+
+	virtual const pv::util::Timestamp delta(const pv::util::Timestamp& other) const override;
 
 	/**
 	 * Gets the arrow-tip point of the time marker.

--- a/pv/views/trace/view.cpp
+++ b/pv/views/trace/view.cpp
@@ -790,22 +790,37 @@ bool View::cursors_shown() const
 
 void View::show_cursors(bool show)
 {
-	show_cursors_ = show;
-	cursor_state_changed(show);
-	ruler_->update();
-	viewport_->update();
+    if (show_cursors_ != show) {
+        show_cursors_ = show;
+        cursor_state_changed(show);
+        ruler_->update();
+        viewport_->update();
+
+    } else {
+        show_cursors_ = show;
+    }
+}
+
+void View::set_cursors(pv::util::Timestamp& first, pv::util::Timestamp& second) {
+    assert(cursors);
+
+    cursors_->first()->set_time(first);
+    cursors_->second()->set_time(second);
+
+    ruler_->update();
+    viewport_->update();
 }
 
 void View::centre_cursors()
 {
-	if (cursors_) {
-		const double time_width = scale_ * viewport_->width();
-		cursors_->first()->set_time(offset_ + time_width * 0.4);
-		cursors_->second()->set_time(offset_ + time_width * 0.6);
+    assert(cursors);
 
-		ruler_->update();
-		viewport_->update();
-	}
+    const double time_width = scale_ * viewport_->width();
+    cursors_->first()->set_time(offset_ + time_width * 0.4);
+    cursors_->second()->set_time(offset_ + time_width * 0.6);
+
+    ruler_->update();
+    viewport_->update();
 }
 
 shared_ptr<CursorPair> View::cursors() const

--- a/pv/views/trace/view.cpp
+++ b/pv/views/trace/view.cpp
@@ -129,7 +129,7 @@ View::View(Session &session, bool is_main_view, QWidget *parent) :
 
 	// Note: Place defaults in View::reset_view_state(), not here
 	splitter_(new QSplitter()),
-	header_was_shrunk_(false),  // The splitter remains unchanged after a reset, so this goes here
+	header_was_shrunk_(false),	// The splitter remains unchanged after a reset, so this goes here
 	sticky_scrolling_(false)  // Default setting is set in MainWindow::setup_ui()
 {
 	QVBoxLayout *root_layout = new QVBoxLayout(this);
@@ -168,8 +168,8 @@ View::View(Session &session, bool is_main_view, QWidget *parent) :
 	splitter_->setHandleWidth(1);  // Don't show a visible rubber band
 	splitter_->setCollapsible(0, false);  // Prevent the header from collapsing
 	splitter_->setCollapsible(1, false);  // Prevent the traces from collapsing
-	splitter_->setStretchFactor(0, 0);  // Prevent the panes from being resized
-	splitter_->setStretchFactor(1, 1);  // when the entire view is resized
+	splitter_->setStretchFactor(0, 0);	// Prevent the panes from being resized
+	splitter_->setStretchFactor(1, 1);	// when the entire view is resized
 	splitter_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
 	viewport_->installEventFilter(this);
@@ -443,6 +443,11 @@ vector< shared_ptr<TimeItem> > View::time_items() const
 	return items;
 }
 
+shared_ptr<TimeItem> View::get_reference_time_item()
+{
+	return ruler_->get_reference_item();
+}
+
 double View::scale() const
 {
 	return scale_;
@@ -458,12 +463,12 @@ void View::set_scale(double scale)
 
 pv::util::Timestamp View::absolute_to_ruler_time(const pv::util::Timestamp& abs_time) const
 {
-    return abs_time + zero_offset_;
+	return abs_time + zero_offset_;
 }
 
 pv::util::Timestamp View::ruler_to_absolute_time(const pv::util::Timestamp& ruler_time) const
 {
-    return ruler_time - zero_offset_;
+	return ruler_time - zero_offset_;
 }
 
 void View::set_offset(const pv::util::Timestamp& offset, bool force_update)
@@ -754,10 +759,10 @@ pair<Timestamp, Timestamp> View::get_time_extents() const
 			const Timestamp start_time = s->start_time();
 			left_time = left_time ?
 				min(*left_time, start_time) :
-				                start_time;
+								start_time;
 			right_time = right_time ?
 				max(*right_time, start_time + d->max_sample_count() / samplerate) :
-				                 start_time + d->max_sample_count() / samplerate;
+								 start_time + d->max_sample_count() / samplerate;
 		}
 	}
 
@@ -800,37 +805,37 @@ bool View::cursors_shown() const
 
 void View::show_cursors(bool show)
 {
-    if (show_cursors_ != show) {
-        show_cursors_ = show;
-        cursor_state_changed(show);
-        ruler_->update();
-        viewport_->update();
+	if (show_cursors_ != show) {
+		show_cursors_ = show;
+		cursor_state_changed(show);
+		ruler_->update();
+		viewport_->update();
 
-    } else {
-        show_cursors_ = show;
-    }
+	} else {
+		show_cursors_ = show;
+	}
 }
 
 void View::set_cursors(pv::util::Timestamp& first, pv::util::Timestamp& second) {
-    assert(cursors);
+	assert(cursors);
 
-    cursors_->first()->set_time(first);
-    cursors_->second()->set_time(second);
+	cursors_->first()->set_time(first);
+	cursors_->second()->set_time(second);
 
-    ruler_->update();
-    viewport_->update();
+	ruler_->update();
+	viewport_->update();
 }
 
 void View::centre_cursors()
 {
-    assert(cursors);
+	assert(cursors);
 
-    const double time_width = scale_ * viewport_->width();
-    cursors_->first()->set_time(offset_ + time_width * 0.4);
-    cursors_->second()->set_time(offset_ + time_width * 0.6);
+	const double time_width = scale_ * viewport_->width();
+	cursors_->first()->set_time(offset_ + time_width * 0.4);
+	cursors_->second()->set_time(offset_ + time_width * 0.6);
 
-    ruler_->update();
-    viewport_->update();
+	ruler_->update();
+	viewport_->update();
 }
 
 shared_ptr<CursorPair> View::cursors() const
@@ -838,15 +843,17 @@ shared_ptr<CursorPair> View::cursors() const
 	return cursors_;
 }
 
-void View::add_flag(const Timestamp& time)
+shared_ptr<Flag> View::add_flag(const Timestamp& time)
 {
-	flags_.push_back(make_shared<Flag>(*this, time,
-		QString("%1").arg(next_flag_text_)));
+	shared_ptr<Flag> flag = make_shared<Flag>(
+			*this, time, QString("%1").arg(next_flag_text_));
+	flags_.push_back(flag);
 
 	next_flag_text_ = (next_flag_text_ >= 'Z') ? 'A' :
 		(next_flag_text_ + 1);
 
 	time_item_appearance_changed(true, true);
+	return flag;
 }
 
 void View::remove_flag(shared_ptr<Flag> flag)

--- a/pv/views/trace/view.cpp
+++ b/pv/views/trace/view.cpp
@@ -456,6 +456,16 @@ void View::set_scale(double scale)
 	}
 }
 
+pv::util::Timestamp View::absolute_to_ruler_time(const pv::util::Timestamp& abs_time) const
+{
+    return abs_time + zero_offset_;
+}
+
+pv::util::Timestamp View::ruler_to_absolute_time(const pv::util::Timestamp& ruler_time) const
+{
+    return ruler_time - zero_offset_;
+}
+
 void View::set_offset(const pv::util::Timestamp& offset, bool force_update)
 {
 	if ((offset_ != offset) || force_update) {

--- a/pv/views/trace/view.hpp
+++ b/pv/views/trace/view.hpp
@@ -177,6 +177,9 @@ public:
 
 	void reset_zero_position();
 
+    pv::util::Timestamp absolute_to_ruler_time(const pv::util::Timestamp& abs_time) const;
+    pv::util::Timestamp ruler_to_absolute_time(const pv::util::Timestamp& ruler_time) const;
+
 	/**
 	 * Returns the vertical scroll offset.
 	 */

--- a/pv/views/trace/view.hpp
+++ b/pv/views/trace/view.hpp
@@ -156,6 +156,8 @@ public:
 	 */
 	vector< shared_ptr<TimeItem> > time_items() const;
 
+	shared_ptr<TimeItem> get_reference_time_item();
+
 	/**
 	 * Returns the view time scale in seconds per pixel.
 	 */
@@ -299,7 +301,7 @@ public:
 	/**
 	 * Adds a new flag at a specified time.
 	 */
-	void add_flag(const pv::util::Timestamp& time);
+	shared_ptr<Flag> add_flag(const pv::util::Timestamp& time);
 
 	/**
 	 * Removes a flag from the list.

--- a/pv/views/trace/view.hpp
+++ b/pv/views/trace/view.hpp
@@ -278,6 +278,11 @@ public:
 	 */
 	void show_cursors(bool show = true);
 
+    /**
+     * Sets the cursors to the given offsets. You will still have to call show_cursors separately.
+     */
+    void set_cursors(pv::util::Timestamp& first, pv::util::Timestamp& second);
+
 	/**
 	 * Moves the cursors to a convenient position in the view.
 	 */

--- a/pv/views/trace/viewwidget.cpp
+++ b/pv/views/trace/viewwidget.cpp
@@ -283,10 +283,27 @@ void ViewWidget::mouseReleaseEvent(QMouseEvent *event)
 	mouse_down_item_ = nullptr;
 }
 
+void ViewWidget::keyReleaseEvent(QKeyEvent *event)
+{
+	// Update mouse_modifiers_ also if modifiers change, but pointer doesn't move
+	if (mouse_point_.x() >= 0 && mouse_point_.y() >= 0) // mouse is inside
+		mouse_modifiers_ = event->modifiers();
+	update();
+}
+
+void ViewWidget::keyPressEvent(QKeyEvent *event)
+{
+	// Update mouse_modifiers_ also if modifiers change, but pointer doesn't move
+	if (mouse_point_.x() >= 0 && mouse_point_.y() >= 0) // mouse is inside
+		mouse_modifiers_ = event->modifiers();
+	update();
+}
+
 void ViewWidget::mouseMoveEvent(QMouseEvent *event)
 {
 	assert(event);
 	mouse_point_ = event->pos();
+	mouse_modifiers_ = event->modifiers();
 
 	if (!event->buttons()) {
 		item_hover(get_mouse_over_item(event->pos()), event->pos());
@@ -326,6 +343,8 @@ void ViewWidget::mouseMoveEvent(QMouseEvent *event)
 void ViewWidget::leaveEvent(QEvent*)
 {
 	mouse_point_ = QPoint(-1, -1);
+	mouse_modifiers_ = Qt::NoModifier;
+	item_hover(nullptr, QPoint());
 	update();
 }
 

--- a/pv/views/trace/viewwidget.hpp
+++ b/pv/views/trace/viewwidget.hpp
@@ -25,6 +25,8 @@
 #include <QPoint>
 #include <QWidget>
 
+#include <pv/util.hpp>
+
 using std::shared_ptr;
 using std::vector;
 
@@ -143,6 +145,7 @@ protected:
 	pv::views::trace::View &view_;
 	QPoint mouse_point_;
 	QPoint mouse_down_point_;
+	pv::util::Timestamp mouse_down_offset_;
 	shared_ptr<ViewItem> mouse_down_item_;
 	bool item_dragging_;
 };

--- a/pv/views/trace/viewwidget.hpp
+++ b/pv/views/trace/viewwidget.hpp
@@ -133,6 +133,9 @@ protected:
 	void mouseReleaseEvent(QMouseEvent *event);
 	void mouseMoveEvent(QMouseEvent *event);
 
+	void keyPressEvent(QKeyEvent *event);
+	void keyReleaseEvent(QKeyEvent *event);
+
 	void leaveEvent(QEvent *event);
 
 public Q_SLOTS:
@@ -144,6 +147,7 @@ Q_SIGNALS:
 protected:
 	pv::views::trace::View &view_;
 	QPoint mouse_point_;
+	Qt::KeyboardModifiers mouse_modifiers_;
 	QPoint mouse_down_point_;
 	pv::util::Timestamp mouse_down_offset_;
 	shared_ptr<ViewItem> mouse_down_item_;

--- a/pv/widgets/timestampspinbox.cpp
+++ b/pv/widgets/timestampspinbox.cpp
@@ -31,6 +31,7 @@ TimestampSpinBox::TimestampSpinBox(QWidget* parent)
 	, stepsize_("1e-6")
 {
 	connect(this, SIGNAL(editingFinished()), this, SLOT(on_editingFinished()));
+	connect(lineEdit(), SIGNAL(editingFinished()), this, SLOT(on_editingFinished()));
 
 	updateEdit();
 }
@@ -92,10 +93,6 @@ void TimestampSpinBox::setValue(const pv::util::Timestamp& val)
 
 void TimestampSpinBox::on_editingFinished()
 {
-	if (!lineEdit()->isModified())
-		return;
-	lineEdit()->setModified(false);
-
 	QRegExp re(R"(\s*([-+]?)\s*([0-9]+\.?[0-9]*).*)");
 
 	if (re.exactMatch(text())) {
@@ -103,6 +100,7 @@ void TimestampSpinBox::on_editingFinished()
 		captures.removeFirst(); // remove entire match
 		QString str = captures.join("");
 		setValue(pv::util::Timestamp(str.toStdString()));
+
 	} else {
 		// replace the malformed entered string with the old value
 		updateEdit();
@@ -113,7 +111,11 @@ void TimestampSpinBox::updateEdit()
 {
 	QString newtext = pv::util::format_time_si(
 		value_, pv::util::SIPrefix::none, precision_);
+	const QSignalBlocker blocker(lineEdit());
+	// Keep cursor position
+	int cursor = lineEdit()->cursorPosition();
 	lineEdit()->setText(newtext);
+	lineEdit()->setCursorPosition(cursor);
 }
 
 }  // namespace widgets


### PR DESCRIPTION
This is a set of some smaller changes to how flags and cursors behave. This closes #15, fixing the issue in a IMHO better way. The changes are:

* Allow the cursors to be set via shift-drag in the signal scroll area.
* Make the cursor pair time difference label drop precision when there is not enough space. The tooltip/popup behavior is kept. (closes #15)
* Respect the custom ruler zero point in flag popups and cursor labels.
* Bugfix: Ruler double-click flag adding now also works with a custom zero point set.
* Accept a new flag position when enter is pressed inside the popup input field.
* When hovering a flag or cursor, change the labels of other flags to show their relative time to the hovered flag or cursor. Pressing shift changes back to their original labels for easy access.