### PR TITLE
Rework channel selection popup

### DIFF
--- a/pv/popups/channels.cpp
+++ b/pv/popups/channels.cpp
@@ -40,6 +40,7 @@ using std::make_shared;
 using std::map;
 using std::out_of_range;
 using std::shared_ptr;
+using std::weak_ptr;
 using std::unordered_set;
 using std::vector;
 
@@ -56,19 +57,11 @@ namespace popups {
 
 Channels::Channels(Session &session, QWidget *parent) :
 	Popup(parent),
-	session_(session),
-	updating_channels_(false),
+    session_(session),
 	enable_all_channels_(tr("All"), this),
-	disable_all_channels_(tr("All"), this),
-	enable_all_logic_channels_(tr("Logic"), this),
-	disable_all_logic_channels_(tr("Logic"), this),
-	enable_all_analog_channels_(tr("Analog"), this),
-	disable_all_analog_channels_(tr("Analog"), this),
-	enable_all_named_channels_(tr("Named"), this),
-	disable_all_unnamed_channels_(tr("Unnamed"), this),
-	enable_all_changing_channels_(tr("Changing"), this),
-	disable_all_non_changing_channels_(tr("Non-changing"), this),
-	check_box_mapper_(this)
+	disable_all_channels_(tr("None"), this),
+	enable_only_named_channels_(tr("Named"), this),
+	enable_only_changing_channels_(tr("Changing"), this)
 {
 	// Create the layout
 	setLayout(&layout_);
@@ -126,99 +119,62 @@ Channels::Channels(Session &session, QWidget *parent) :
 	// Create the enable/disable all buttons
 	connect(&enable_all_channels_, SIGNAL(clicked()), this, SLOT(enable_all_channels()));
 	connect(&disable_all_channels_, SIGNAL(clicked()), this, SLOT(disable_all_channels()));
-	connect(&enable_all_logic_channels_, SIGNAL(clicked()), this, SLOT(enable_all_logic_channels()));
-	connect(&disable_all_logic_channels_, SIGNAL(clicked()), this, SLOT(disable_all_logic_channels()));
-	connect(&enable_all_analog_channels_, SIGNAL(clicked()), this, SLOT(enable_all_analog_channels()));
-	connect(&disable_all_analog_channels_, SIGNAL(clicked()), this, SLOT(disable_all_analog_channels()));
-	connect(&enable_all_named_channels_, SIGNAL(clicked()), this, SLOT(enable_all_named_channels()));
-	connect(&disable_all_unnamed_channels_, SIGNAL(clicked()), this, SLOT(disable_all_unnamed_channels()));
-	connect(&enable_all_changing_channels_, SIGNAL(clicked()),
-		this, SLOT(enable_all_changing_channels()));
-	connect(&disable_all_non_changing_channels_, SIGNAL(clicked()),
-		this, SLOT(disable_all_non_changing_channels()));
+	connect(&enable_only_named_channels_, SIGNAL(clicked()), this, SLOT(enable_only_named_channels()));
+	connect(&enable_only_changing_channels_, SIGNAL(clicked()), this, SLOT(enable_only_changing_channels()));
 
-	QLabel *label1 = new QLabel(tr("Disable: "));
-	filter_buttons_bar_.addWidget(label1, 0, 0);
-	filter_buttons_bar_.addWidget(&disable_all_channels_, 0, 1);
-	filter_buttons_bar_.addWidget(&disable_all_logic_channels_, 0, 2);
-	filter_buttons_bar_.addWidget(&disable_all_analog_channels_, 0, 3);
-	filter_buttons_bar_.addWidget(&disable_all_unnamed_channels_, 0, 4);
-	filter_buttons_bar_.addWidget(&disable_all_non_changing_channels_, 0, 5);
+    // Count analog and logic channels to decide which filter buttons to show
+    int analog_channels = 0, logic_channels = 0;
+	for (auto& entry : check_box_signal_map_) {
+		const shared_ptr<SignalBase> sig = entry.second;
+		assert(sig);
+        if (sig->type() == SignalBase::AnalogChannel)
+            analog_channels++;
+        else if (sig->type() == SignalBase::LogicChannel)
+            logic_channels++;
+    }
 
-	QLabel *label2 = new QLabel(tr("Enable: "));
-	filter_buttons_bar_.addWidget(label2, 1, 0);
-	filter_buttons_bar_.addWidget(&enable_all_channels_, 1, 1);
-	filter_buttons_bar_.addWidget(&enable_all_logic_channels_, 1, 2);
-	filter_buttons_bar_.addWidget(&enable_all_analog_channels_, 1, 3);
-	filter_buttons_bar_.addWidget(&enable_all_named_channels_, 1, 4);
-	filter_buttons_bar_.addWidget(&enable_all_changing_channels_, 1, 5);
+	filter_buttons_bar_.addWidget(&enable_all_channels_);
+	filter_buttons_bar_.addWidget(&disable_all_channels_);
+    // Only show logic/analog buttons if both logic and analog channels are shown
+    if (logic_channels > 0 && analog_channels > 0) {
+        enable_only_logic_channels_ = new QPushButton(tr("Logic"), this);
+        enable_only_analog_channels_ = new QPushButton(tr("Analog"), this);
+        connect(enable_only_logic_channels_, SIGNAL(clicked()), this, SLOT(enable_only_logic_channels()));
+        connect(enable_only_analog_channels_, SIGNAL(clicked()), this, SLOT(enable_only_analog_channels()));
+        filter_buttons_bar_.addWidget(enable_only_logic_channels_);
+        filter_buttons_bar_.addWidget(enable_only_analog_channels_);
+    }
+	filter_buttons_bar_.addWidget(&enable_only_named_channels_);
+	filter_buttons_bar_.addWidget(&enable_only_changing_channels_);
 
 	layout_.addItem(new QSpacerItem(0, 15, QSizePolicy::Expanding, QSizePolicy::Expanding));
 	layout_.addRow(&filter_buttons_bar_);
-
-	// Connect the check-box signal mapper
-	connect(&check_box_mapper_, SIGNAL(mapped(QWidget*)),
-		this, SLOT(on_channel_checked(QWidget*)));
 }
 
-void Channels::set_all_channels(bool set)
+void Channels::set_all_channels(bool value)
 {
-	updating_channels_ = true;
-
-	for (auto& entry : check_box_signal_map_) {
-		QCheckBox *cb = entry.first;
-		const shared_ptr<SignalBase> sig = entry.second;
-		assert(sig);
-
-		sig->set_enabled(set);
-		cb->setChecked(set);
-	}
-
-	updating_channels_ = false;
+	for (auto& entry : check_box_signal_map_)
+        entry.first->setChecked(value);
 }
 
-void Channels::enable_channels_conditionally(
+void Channels::set_channels_to_condition(
 	function<bool (const shared_ptr<data::SignalBase>)> cond_func)
 {
-	updating_channels_ = true;
-
 	for (auto& entry : check_box_signal_map_) {
 		QCheckBox *cb = entry.first;
 		const shared_ptr<SignalBase> sig = entry.second;
 		assert(sig);
 
-		if (cond_func(sig)) {
-			sig->set_enabled(true);
-			cb->setChecked(true);
-		}
+        cb->setChecked(cond_func(sig));
 	}
-
-	updating_channels_ = false;
 }
 
-void Channels::disable_channels_conditionally(
-	function<bool (const shared_ptr<data::SignalBase>)> cond_func)
-{
-	updating_channels_ = true;
-
-	for (auto& entry : check_box_signal_map_) {
-		QCheckBox *cb = entry.first;
-		const shared_ptr<SignalBase> sig = entry.second;
-		assert(sig);
-
-		if (cond_func(sig)) {
-			sig->set_enabled(false);
-			cb->setChecked(false);
-		}
-	}
-
-	updating_channels_ = false;
-}
 
 void Channels::populate_group(shared_ptr<ChannelGroup> group,
 	const vector< shared_ptr<SignalBase> > sigs)
 {
 	using pv::binding::Device;
+    QPushButton *enable_all_button = NULL, *disable_all_button = NULL;
 
 	// Only bind options if this is a group. We don't do it for general
 	// options, because these properties are shown in the device config
@@ -228,48 +184,91 @@ void Channels::populate_group(shared_ptr<ChannelGroup> group,
 		binding = make_shared<Device>(group);
 
 	// Create a title if the group is going to have any content
+    QHBoxLayout *group_label_box = new QHBoxLayout();
 	if ((!sigs.empty() || (binding && !binding->properties().empty())) && group)
 	{
 		QLabel *label = new QLabel(
 			QString("<h3>%1</h3>").arg(group->name().c_str()));
-		layout_.addRow(label);
+		group_label_box->addWidget(label);
 		group_label_map_[group] = label;
-	}
+    }
+
+    if (sigs.size() >= 2) {
+        // Create enable all/none buttons
+        enable_all_button = new QPushButton(tr("All"), this);
+        group_label_box->addWidget(enable_all_button);
+        disable_all_button = new QPushButton(tr("None"), this);
+        group_label_box->addWidget(disable_all_button);
+    }
+    layout_.addRow(group_label_box);
 
 	// Create the channel group grid
-	QGridLayout *const channel_grid = create_channel_group_grid(sigs);
-	layout_.addRow(channel_grid);
+    int row = 0, col = 0;
+	QGridLayout *const grid = new QGridLayout();
+
+    vector< QCheckBox* > group_checkboxes;
+    vector< QCheckBox* > this_row;
+	for (const shared_ptr<SignalBase>& sig : sigs) {
+		assert(sig);
+
+		QCheckBox *const checkbox = new QCheckBox(sig->display_name());
+		grid->addWidget(checkbox, row, col);
+        group_checkboxes.push_back(checkbox);
+        this_row.push_back(checkbox);
+
+        check_box_signal_map_[checkbox] = sig;
+
+        weak_ptr<SignalBase> weak_sig(sig);
+		connect(checkbox, &QCheckBox::toggled,
+            [weak_sig](bool state) {
+                auto sig = weak_sig.lock();
+                assert(sig);
+                sig->set_enabled(state);
+            });
+
+		if ((++col >= 8 || &sig == &sigs.back())) {
+            // Show buttons if there's more than one row
+            if (sigs.size() > 8) {
+                QPushButton *row_enable_button = new QPushButton(tr("All"), this);
+                grid->addWidget(row_enable_button, row, 8);
+                connect(row_enable_button, &QPushButton::clicked,
+                    [this_row]() {
+                        for (QCheckBox *box : this_row)
+                            box->setChecked(true);
+                    });
+
+                QPushButton *row_disable_button = new QPushButton(tr("None"), this);
+                connect(row_disable_button, &QPushButton::clicked,
+                    [this_row]() {
+                        for (QCheckBox *box : this_row)
+                            box->setChecked(false);
+                    });
+                grid->addWidget(row_disable_button, row, 9);
+            }
+
+            this_row.clear();
+			col = 0, row++;
+        }
+	}
+	layout_.addRow(grid);
+
+    if (enable_all_button && disable_all_button) {
+        connect(enable_all_button, &QPushButton::clicked, [group_checkboxes](){
+                for (QCheckBox *box: group_checkboxes)
+                    box->setChecked(true);
+            });
+
+        connect(disable_all_button, &QPushButton::clicked, [group_checkboxes](){
+                for (QCheckBox *box: group_checkboxes)
+                    box->setChecked(false);
+            });
+    }
 
 	// Create the channel group options
 	if (binding) {
 		binding->add_properties_to_form(&layout_, true);
 		group_bindings_.push_back(binding);
 	}
-}
-
-QGridLayout* Channels::create_channel_group_grid(
-	const vector< shared_ptr<SignalBase> > sigs)
-{
-	int row = 0, col = 0;
-	QGridLayout *const grid = new QGridLayout();
-
-	for (const shared_ptr<SignalBase>& sig : sigs) {
-		assert(sig);
-
-		QCheckBox *const checkbox = new QCheckBox(sig->display_name());
-		check_box_mapper_.setMapping(checkbox, checkbox);
-		connect(checkbox, SIGNAL(toggled(bool)),
-			&check_box_mapper_, SLOT(map()));
-
-		grid->addWidget(checkbox, row, col);
-
-		check_box_signal_map_[checkbox] = sig;
-
-		if (++col >= 8)
-			col = 0, row++;
-	}
-
-	return grid;
 }
 
 void Channels::showEvent(QShowEvent *event)
@@ -291,38 +290,16 @@ void Channels::showEvent(QShowEvent *event)
 		}
 	}
 
-	updating_channels_ = true;
-
 	for (auto& entry : check_box_signal_map_) {
 		QCheckBox *cb = entry.first;
 		const shared_ptr<SignalBase> sig = entry.second;
 		assert(sig);
 
 		// Update the check box
+        QSignalBlocker blocker(cb);
 		cb->setChecked(sig->enabled());
 		cb->setText(sig->display_name());
 	}
-
-	updating_channels_ = false;
-}
-
-void Channels::on_channel_checked(QWidget *widget)
-{
-	if (updating_channels_)
-		return;
-
-	QCheckBox *const check_box = (QCheckBox*)widget;
-	assert(check_box);
-
-	// Look up the signal of this check-box
-	map< QCheckBox*, shared_ptr<SignalBase> >::const_iterator iter =
-		check_box_signal_map_.find((QCheckBox*)check_box);
-	assert(iter != check_box_signal_map_.end());
-
-	const shared_ptr<SignalBase> s = (*iter).second;
-	assert(s);
-
-	s->set_enabled(check_box->isChecked());
 }
 
 void Channels::enable_all_channels()
@@ -335,106 +312,57 @@ void Channels::disable_all_channels()
 	set_all_channels(false);
 }
 
-void Channels::enable_all_logic_channels()
+void Channels::enable_only_named_channels()
 {
-	enable_channels_conditionally([](const shared_ptr<SignalBase> signal)
-		{ return signal->type() == SignalBase::LogicChannel; });
-}
-
-void Channels::disable_all_logic_channels()
-{
-	disable_channels_conditionally([](const shared_ptr<SignalBase> signal)
-		{ return signal->type() == SignalBase::LogicChannel; });
-}
-
-void Channels::enable_all_analog_channels()
-{
-	enable_channels_conditionally([](const shared_ptr<SignalBase> signal)
-		{ return signal->type() == SignalBase::AnalogChannel; });
-}
-
-void Channels::disable_all_analog_channels()
-{
-	disable_channels_conditionally([](const shared_ptr<SignalBase> signal)
-		{ return signal->type() == SignalBase::AnalogChannel; });
-}
-
-void Channels::enable_all_named_channels()
-{
-	enable_channels_conditionally([](const shared_ptr<SignalBase> signal)
+	set_channels_to_condition([](const shared_ptr<SignalBase> signal)
 		{ return signal->name() != signal->internal_name(); });
 }
 
-void Channels::disable_all_unnamed_channels()
+void Channels::enable_only_logic_channels()
 {
-	disable_channels_conditionally([](const shared_ptr<SignalBase> signal)
-		{ return signal->name() == signal->internal_name(); });
+	set_channels_to_condition([](const shared_ptr<SignalBase> signal)
+		{ return signal->type() == SignalBase::LogicChannel; });
 }
 
-void Channels::enable_all_changing_channels()
+void Channels::enable_only_analog_channels()
 {
-	enable_channels_conditionally([](const shared_ptr<SignalBase> signal)
-		{
-			// Never enable channels without sample data
-			if (!signal->has_samples())
-				return false;
-
-			// Non-logic channels are considered to always have a signal
-			if (signal->type() != SignalBase::LogicChannel)
-				return true;
-
-			const shared_ptr<Logic> logic = signal->logic_data();
-			assert(logic);
-
-			// If any of the segments has edges, enable this channel
-			for (shared_ptr<LogicSegment> segment : logic->logic_segments()) {
-				vector<LogicSegment::EdgePair> edges;
-
-				segment->get_subsampled_edges(edges,
-					0, segment->get_sample_count() - 1,
-					LogicSegment::MipMapScaleFactor,
-					signal->index());
-
-				if (edges.size() > 2)
-					return true;
-			}
-
-			// No edges detected in any of the segments
-			return false;
-		});
+	set_channels_to_condition([](const shared_ptr<SignalBase> signal)
+		{ return signal->type() == SignalBase::AnalogChannel; });
 }
 
-void Channels::disable_all_non_changing_channels()
+void Channels::enable_only_changing_channels()
 {
-	disable_channels_conditionally([](const shared_ptr<SignalBase> signal)
-		{
-			// Always disable channels without sample data
-			if (!signal->has_samples())
-				return true;
+	set_channels_to_condition([](const shared_ptr<SignalBase> signal)
+		{ return has_signal(signal); });
+}
 
-			// Non-logic channels are considered to always have a signal
-			if (signal->type() != SignalBase::LogicChannel)
-				return false;
+bool Channels::has_signal(const shared_ptr<SignalBase> signal) {
+    // Always disable channels without sample data
+    if (!signal->has_samples())
+        return false;
 
-			const shared_ptr<Logic> logic = signal->logic_data();
-			assert(logic);
+    // Non-logic channels are considered to always have a signal
+    if (signal->type() != SignalBase::LogicChannel)
+        return true;
 
-			// If any of the segments has edges, leave this channel enabled
-			for (shared_ptr<LogicSegment> segment : logic->logic_segments()) {
-				vector<LogicSegment::EdgePair> edges;
+    const shared_ptr<Logic> logic = signal->logic_data();
+    assert(logic);
 
-				segment->get_subsampled_edges(edges,
-					0, segment->get_sample_count() - 1,
-					LogicSegment::MipMapScaleFactor,
-					signal->index());
+    // If any of the segments has edges, leave this channel enabled
+    for (shared_ptr<LogicSegment> segment : logic->logic_segments()) {
+        vector<LogicSegment::EdgePair> edges;
 
-				if (edges.size() > 2)
-					return false;
-			}
+        segment->get_subsampled_edges(edges,
+            0, segment->get_sample_count() - 1,
+            LogicSegment::MipMapScaleFactor,
+            signal->index());
 
-			// No edges detected in any of the segments
-			return true;
-		});
+        if (edges.size() > 2)
+            return true;
+    }
+
+    // No edges detected in any of the segments
+    return false;
 }
 
 }  // namespace popups

--- a/pv/popups/channels.hpp
+++ b/pv/popups/channels.hpp
@@ -27,7 +27,7 @@
 
 #include <QCheckBox>
 #include <QFormLayout>
-#include <QGridLayout>
+#include <QHBoxLayout>
 #include <QLabel>
 #include <QPushButton>
 #include <QSignalMapper>
@@ -69,55 +69,41 @@ public:
 	Channels(Session &session, QWidget *parent);
 
 private:
-	void set_all_channels(bool set);
-
-	void enable_channels_conditionally(
-		function<bool (const shared_ptr<data::SignalBase>)> cond_func);
-	void disable_channels_conditionally(
+	void set_all_channels(bool value);
+	void set_channels_to_condition(
 		function<bool (const shared_ptr<data::SignalBase>)> cond_func);
 
 	void populate_group(shared_ptr<sigrok::ChannelGroup> group,
 		const vector< shared_ptr<pv::data::SignalBase> > sigs);
 
-	QGridLayout* create_channel_group_grid(
-		const vector< shared_ptr<pv::data::SignalBase> > sigs);
-
 	void showEvent(QShowEvent *event);
 
-private Q_SLOTS:
-	void on_channel_checked(QWidget *widget);
+    static bool has_signal(const shared_ptr<pv::data::SignalBase> signal);
 
+private Q_SLOTS:
 	void enable_all_channels();
 	void disable_all_channels();
-	void enable_all_logic_channels();
-	void disable_all_logic_channels();
-	void enable_all_analog_channels();
-	void disable_all_analog_channels();
-	void enable_all_named_channels();
-	void disable_all_unnamed_channels();
-	void enable_all_changing_channels();
-	void disable_all_non_changing_channels();
+	void enable_only_logic_channels();
+	void enable_only_analog_channels();
+	void enable_only_named_channels();
+	void enable_only_changing_channels();
 
 private:
 	pv::Session &session_;
 
 	QFormLayout layout_;
 
-	bool updating_channels_;
-
-	vector< shared_ptr<pv::binding::Device> > group_bindings_;
 	map< QCheckBox*, shared_ptr<pv::data::SignalBase> >
 		check_box_signal_map_;
+	vector< shared_ptr<pv::binding::Device> > group_bindings_;
 	map< shared_ptr<sigrok::ChannelGroup>, QLabel*> group_label_map_;
 
-	QGridLayout filter_buttons_bar_;
+	QHBoxLayout filter_buttons_bar_;
 	QPushButton enable_all_channels_, disable_all_channels_;
-	QPushButton enable_all_logic_channels_, disable_all_logic_channels_;
-	QPushButton enable_all_analog_channels_, disable_all_analog_channels_;
-	QPushButton enable_all_named_channels_, disable_all_unnamed_channels_;
-	QPushButton enable_all_changing_channels_, disable_all_non_changing_channels_;
-
-	QSignalMapper check_box_mapper_;
+	QPushButton *enable_only_logic_channels_;
+	QPushButton *enable_only_analog_channels_;
+	QPushButton enable_only_named_channels_;
+	QPushButton enable_only_changing_channels_;
 };
 
 }  // namespace popups


### PR DESCRIPTION
Change the channel selection popup to make select-multiple more
intuitive.

* Show select all/none buttons per group
* Show select all/none buttons per row of 8 channels
* Show select analog/logic buttons only when both types are present
* Move away from separate enable-*/disable-* (changing, named) and
  to enable-only-*.