### PR TITLE
Add shortcuts for attaching the ruler's cursors to the mouse

### DIFF
--- a/pv/mainwindow.cpp
+++ b/pv/mainwindow.cpp
@@ -517,6 +517,17 @@ void MainWindow::setup_ui()
 	zoom_out_shortcut_ = new QShortcut(QKeySequence(Qt::Key_Minus), this, SLOT(on_zoom_out_shortcut_triggered()));
 	zoom_out_shortcut_->setAutoRepeat(false);
 
+	grab_ruler_left_shortcut_ = new QShortcut(QKeySequence(Qt::Key_0), this);
+	connect(grab_ruler_left_shortcut_, &QShortcut::activated, this, [=]{on_grab_ruler(true);});
+	grab_ruler_left_shortcut_->setAutoRepeat(false);
+
+	grab_ruler_right_shortcut_ = new QShortcut(QKeySequence(Qt::Key_1), this);
+	connect(grab_ruler_right_shortcut_, &QShortcut::activated, this, [=]{on_grab_ruler(false);});
+	grab_ruler_right_shortcut_->setAutoRepeat(false);
+
+	exit_grab_shortcut_ = new QShortcut(QKeySequence(Qt::Key_Escape), this, SLOT(on_cancel_grab()));
+	exit_grab_shortcut_->setAutoRepeat(false);
+
 	// Set up the tab area
 	new_session_button_ = new QToolButton();
 	new_session_button_->setIcon(QIcon::fromTheme("document-new",
@@ -976,6 +987,36 @@ void MainWindow::on_zoom_out_shortcut_triggered()
 void MainWindow::on_zoom_in_shortcut_triggered()
 {
 	zoom_current_view(1);
+}
+
+void MainWindow::on_grab_ruler(bool first)
+{
+	shared_ptr<Session> session = get_tab_session(session_selector_.currentIndex());
+
+	if (!session)
+		return;
+	shared_ptr<views::ViewBase> v = session.get()->main_view();
+	views::trace::View *tv =
+			qobject_cast<views::trace::View*>(v.get());
+	if (tv->cursors_shown()) {
+		if (first)
+			tv->set_grabbed_widget(tv->cursors()->first().get());
+		else
+			tv->set_grabbed_widget(tv->cursors()->second().get());
+	}
+}
+
+void MainWindow::on_cancel_grab()
+{
+	shared_ptr<Session> session = get_tab_session(session_selector_.currentIndex());
+
+	if (!session)
+		return;
+
+	shared_ptr<views::ViewBase> v = session.get()->main_view();
+	views::trace::View *tv =
+		qobject_cast<views::trace::View*>(v.get());
+	tv->clear_grabbed_widget();
 }
 
 void MainWindow::on_close_current_tab()

--- a/pv/mainwindow.hpp
+++ b/pv/mainwindow.hpp
@@ -153,6 +153,9 @@ private Q_SLOTS:
 	void on_zoom_out_shortcut_triggered();
 	void on_zoom_in_shortcut_triggered();
 
+	void on_grab_ruler(bool first);
+	void on_cancel_grab();
+
 	void on_close_current_tab();
 
 private:
@@ -184,6 +187,9 @@ private:
 	QShortcut *close_current_tab_shortcut_;
 	QShortcut *zoom_in_shortcut_;
 	QShortcut *zoom_out_shortcut_;
+	QShortcut *grab_ruler_left_shortcut_;
+	QShortcut *grab_ruler_right_shortcut_;
+	QShortcut *exit_grab_shortcut_;
 };
 
 } // namespace pv

--- a/pv/views/trace/view.hpp
+++ b/pv/views/trace/view.hpp
@@ -427,6 +427,9 @@ public:
 
 	void extents_changed(bool horz, bool vert);
 
+	void set_grabbed_widget(TimeMarker *tracked_widget);
+	void clear_grabbed_widget();
+
 private Q_SLOTS:
 
 	void on_signal_name_changed();
@@ -540,6 +543,7 @@ private:
 	vector< shared_ptr<TriggerMarker> > trigger_markers_;
 
 	QWidget* hover_widget_;
+	TimeMarker* grabbed_widget_;
 	QPoint hover_point_;
 	shared_ptr<Signal> signal_under_mouse_cursor_;
 	uint16_t snap_distance_;


### PR DESCRIPTION
This PR adds shortcuts to the 1 and 2 buttons which activating a mode where the ruler's cursors are dragged by the mouse without clicking/dragging them. The mode could be deactivated by clicking the mouse or pressing the escape button.

The idea have been borrowed from the Saleae Logic where it is used differently. (They use the 0-9 as a shortcut for dragging markers.)

This speeds up the measurement process when having a bunch of digital impulses which length needed to be measured: you can leave one of your hands on the keyboard selecting the left/right marker with the shortcuts and just moving and clicking with the mouse when the cursors are positioned properly. 