### PR TITLE
Add temporary snapping disable menu to the markers

### DIFF
--- a/pv/views/trace/cursor.cpp
+++ b/pv/views/trace/cursor.cpp
@@ -25,6 +25,7 @@
 
 #include <QApplication>
 #include <QBrush>
+#include <QMenu>
 #include <QPainter>
 #include <QPointF>
 #include <QRect>
@@ -87,6 +88,19 @@ QRectF Cursor::label_rect(const QRectF &rect) const
 		return QRectF(x, top, label_size.width(), height);
 	else
 		return QRectF(x - label_size.width(), top, label_size.width(), height);
+}
+
+QMenu *Cursor::create_header_context_menu(QWidget *parent)
+{
+	QMenu *const menu = new QMenu(parent);
+
+	QAction *const snap_disable = new QAction(tr("Disable snapping"), this);
+	snap_disable->setCheckable(true);
+	snap_disable->setChecked(snapping_disabled_);
+	connect(snap_disable, &QAction::toggled, this, [=](bool checked){snapping_disabled_ = checked;});
+	menu->addAction(snap_disable);
+
+	return menu;
 }
 
 shared_ptr<Cursor> Cursor::get_other_cursor() const

--- a/pv/views/trace/cursor.hpp
+++ b/pv/views/trace/cursor.hpp
@@ -67,6 +67,8 @@ public:
 	 */
 	QRectF label_rect(const QRectF &rect) const;
 
+	virtual QMenu* create_header_context_menu(QWidget *parent) override;
+
 private:
 	shared_ptr<Cursor> get_other_cursor() const;
 };

--- a/pv/views/trace/flag.cpp
+++ b/pv/views/trace/flag.cpp
@@ -137,6 +137,12 @@ QMenu* Flag::create_header_context_menu(QWidget *parent)
 	connect(del, SIGNAL(triggered()), this, SLOT(on_delete()));
 	menu->addAction(del);
 
+	QAction *const snap_disable = new QAction(tr("Disable snapping"), this);
+	snap_disable->setCheckable(true);
+	snap_disable->setChecked(snapping_disabled_);
+	connect(snap_disable, &QAction::toggled, this, [=](bool checked){snapping_disabled_ = checked;});
+	menu->addAction(snap_disable);
+
 	return menu;
 }
 

--- a/pv/views/trace/timeitem.cpp
+++ b/pv/views/trace/timeitem.cpp
@@ -31,18 +31,29 @@ TimeItem::TimeItem(View &view) :
 
 void TimeItem::drag_by(const QPoint &delta)
 {
-	int64_t sample_num = view_.get_nearest_level_change(drag_point_ + delta);
-
-	if (sample_num > -1)
-		set_time(sample_num / view_.get_signal_under_mouse_cursor()->base()->get_samplerate());
-	else
+	if (snapping_disabled_) {
 		set_time(view_.offset() + (drag_point_.x() + delta.x() - 0.5) *
 			view_.scale());
+	} else {
+		int64_t sample_num = view_.get_nearest_level_change(drag_point_ + delta);
+
+		if (sample_num > -1)
+			set_time(sample_num / view_.get_signal_under_mouse_cursor()->base()->get_samplerate());
+		else
+			set_time(view_.offset() + (drag_point_.x() + delta.x() - 0.5) *
+				view_.scale());
+	}
 }
 
 const pv::util::Timestamp TimeItem::delta(const pv::util::Timestamp& other) const
 {
 	return other - time();
+}
+
+
+bool TimeItem::is_snapping_disabled() const
+{
+	return snapping_disabled_;
 }
 
 } // namespace trace

--- a/pv/views/trace/timeitem.hpp
+++ b/pv/views/trace/timeitem.hpp
@@ -43,6 +43,8 @@ protected:
 	 */
 	TimeItem(View &view);
 
+	bool snapping_disabled_ = false;
+
 public:
 	/**
 	 * Sets the time of the marker.
@@ -64,6 +66,8 @@ public:
 	 * @param delta the offset from the drag point.
 	 */
 	void drag_by(const QPoint &delta);
+
+	bool is_snapping_disabled() const;
 
 protected:
 	View &view_;


### PR DESCRIPTION
There are some situations when the digital edge snapping makes impossible to move the cursor/marker to a given point for e.g. the marker cannot moved to the inflexion point o the analog channel (with 15px snap distance):
![kép](https://user-images.githubusercontent.com/1609182/60951402-577ee080-a2f9-11e9-980c-d86fddc041dd.png)

This PR adds a right click menu item:
![kép](https://user-images.githubusercontent.com/1609182/60952139-fd7f1a80-a2fa-11e9-9b81-3aab0e7cce37.png)
to the cursors and time markers which could be used to disable the snapping temporary. 

The snapping disable is not saved during sessions, and it is only applied to the selected marker/cursor.