### PR TITLE
adding up/down to zoom in/out for quick navigation

### DIFF
--- a/pv/mainwindow.cpp
+++ b/pv/mainwindow.cpp
@@ -514,8 +514,12 @@ void MainWindow::setup_ui()
 	zoom_in_shortcut_ = new QShortcut(QKeySequence(Qt::Key_Plus), this, SLOT(on_zoom_in_shortcut_triggered()));
 	zoom_in_shortcut_->setAutoRepeat(false);
 
+	zoom_in_shortcut_2_ = new QShortcut(QKeySequence(Qt::Key_Up), this, SLOT(on_zoom_in_shortcut_triggered()));
+
 	zoom_out_shortcut_ = new QShortcut(QKeySequence(Qt::Key_Minus), this, SLOT(on_zoom_out_shortcut_triggered()));
 	zoom_out_shortcut_->setAutoRepeat(false);
+
+	zoom_out_shortcut_2_ = new QShortcut(QKeySequence(Qt::Key_Down), this, SLOT(on_zoom_out_shortcut_triggered()));
 
 	// Set up the tab area
 	new_session_button_ = new QToolButton();

--- a/pv/mainwindow.hpp
+++ b/pv/mainwindow.hpp
@@ -183,7 +183,9 @@ private:
 	QShortcut *close_application_shortcut_;
 	QShortcut *close_current_tab_shortcut_;
 	QShortcut *zoom_in_shortcut_;
+	QShortcut *zoom_in_shortcut_2_;
 	QShortcut *zoom_out_shortcut_;
+	QShortcut *zoom_out_shortcut_2_;
 };
 
 } // namespace pv


### PR DESCRIPTION
previously up/down panned the waveform. after change, shift-up/down and ctrl-up/down still do that.

'+' and '-' are recently mapped to zoom in and zoom out and should probably stay as-is.

After testing, keeping autorepeat on seems to be most intuitive for quickly panning/zooming into the right part of a signal.

Thanks!