### PR TITLE
Ignore touch events generated by a TrackPad.

### DIFF
--- a/pv/views/trace/viewport.cpp
+++ b/pv/views/trace/viewport.cpp
@@ -116,6 +116,9 @@ bool Viewport::touch_event(QTouchEvent *event)
 		pinch_zoom_active_ = false;
 		return false;
 	}
+	if (event->device()->type() == QTouchDevice::TouchPad) {
+		return false;
+	}
 
 	const QTouchEvent::TouchPoint &touchPoint0 = touchPoints.first();
 	const QTouchEvent::TouchPoint &touchPoint1 = touchPoints.last();


### PR DESCRIPTION
This improves trackpad zooming and panning on a Macbook Pro
immensely because it would redraw every touch event. This changes
makes it rely on the mouse wheel events instead.