### PR TITLE
Added the under-the-hood code to support customisation of ...

### DIFF
--- a/pv/views/trace/viewport.cpp
+++ b/pv/views/trace/viewport.cpp
@@ -212,19 +212,9 @@ void Viewport::wheelEvent(QWheelEvent *event)
 	assert(event);
 
 	if (event->orientation() == Qt::Vertical) {
-		if (event->modifiers() & Qt::ControlModifier) {
-			// Vertical scrolling with the control key pressed
-			// is intrepretted as vertical scrolling
-			view_.set_v_offset(-view_.owner_visual_v_offset() -
-				(event->delta() * height()) / (8 * 120));
-		} else {
-			// Vertical scrolling is interpreted as zooming in/out
-			view_.zoom(event->delta() / 120.0, event->x());
-		}
+		view_.on_mw_vert_all(event);
 	} else if (event->orientation() == Qt::Horizontal) {
-		// Horizontal scrolling is interpreted as moving left/right
-		view_.set_scale_offset(view_.scale(),
-			event->delta() * view_.scale() + view_.offset());
+		view_.on_mw_hori_all(event);
 	}
 }
 


### PR DESCRIPTION
keys/mousewheel used to navigate the traces such as for multiple levels of moving and zooming.

The code has default values for these keys which can be changed to whatever you want the default to be.

The code also supports loading and saving of these values from settings.

Missing is a GUI settings page that would allow the user to easily change these customisations. I do not plan to add this code myself as I am not well versed in Qt coding, so hopefully someone else can do this. I did provide get/set functions so that the GUI implementer doesn't need to do any "navigation" coding. They can just do a basic settings page and use the get/set functions provided.

See the comment near the top of View.hpp for info about all of this.