### PR TITLE
Fix for displaying 64 channel data (bug #1317)

### DIFF
--- a/pv/data/logicsegment.cpp
+++ b/pv/data/logicsegment.cpp
@@ -92,7 +92,6 @@ void LogicSegment::downsampleTmain(const T*&in, T &acc, T &prev)
 	}
 }
 
-
 template <>
 void LogicSegment::downsampleTmain<uint8_t>(const uint8_t*&in, uint8_t &acc, uint8_t &prev)
 {

--- a/pv/data/logicsegment.cpp
+++ b/pv/data/logicsegment.cpp
@@ -92,6 +92,7 @@ void LogicSegment::downsampleTmain(const T*&in, T &acc, T &prev)
 	}
 }
 
+
 template <>
 void LogicSegment::downsampleTmain<uint8_t>(const uint8_t*&in, uint8_t &acc, uint8_t &prev)
 {
@@ -643,7 +644,7 @@ void LogicSegment::append_payload_to_mipmap()
 		else if (unit_size_ == 4)
 			downsampleT<uint32_t>(src_ptr, dest_ptr, count);
 		else if (unit_size_ == 8)
-			downsampleT<uint8_t>(src_ptr, dest_ptr, count);
+			downsampleT<uint64_t>(src_ptr, dest_ptr, count);
 		else
 			downsampleGeneric(src_ptr, dest_ptr, count);
 		len_sample -= count;


### PR DESCRIPTION
When working on adding a device to libsigrok with 64 channels I noticed that displaying data did not work as it should. A small part of the data looks OK but most does not. When looking at the buglist of Pulseview I saw there is a bug report for this: 
https://sigrok.org/bugzilla/show_bug.cgi?id=1317
