### PR TITLE
Keyboard shortcuts for "full-page" scroll, and bitmap screenshot capture

### DIFF
--- a/doc/pulseview.1
+++ b/doc/pulseview.1
@@ -143,8 +143,9 @@ analogy with printable document viewers)
 Save a bitmap screen capture (screenshot) of only the ruler and the viewport,
 currently shown in the PulseView window; which allows these screenshots to be
 stitched together horizontally afterwards, if they are obtained through a
-"full-page" scroll. Screenshots are saved in the temporary directory of the OS,
-with a filename of 'pulseview_yyyyMMdd_hhmmss.png' (UTC timestamp).
+"full-page" scroll (note: not pixel-perfect). Screenshots are saved with a
+filename of 'pulseview_yyyyMMdd_hhmmss.png' (UTC timestamp), in the
+temporary directory of the OS.
 .TP
 .B "CTRL+q"
 Quit, i.e. shutdown PulseView (closing all session tabs).

--- a/doc/pulseview.1
+++ b/doc/pulseview.1
@@ -133,6 +133,19 @@ Ungroup the traces in the currently selected trace group.
 .B "CTRL+up/down arrow keys"
 Scroll down/up.
 .TP
+.B "CTRL+m/CTRL+n"
+Scroll forward or backward (right or left) in time (horizontally) for the
+entire width of the capture, currently shown in the PulseView window viewport,
+according to current zoom settings (could be called a "full-page" scroll, by
+analogy with printable document viewers)
+.TP
+.B "CTRL+b"
+Save a bitmap screen capture (screenshot) of only the ruler and the viewport,
+currently shown in the PulseView window; which allows these screenshots to be
+stitched together horizontally afterwards, if they are obtained through a
+"full-page" scroll. Screenshots are saved in the temporary directory of the OS,
+with a filename of 'pulseview_yyyyMMdd_hhmmss.png' (UTC timestamp).
+.TP
 .B "CTRL+q"
 Quit, i.e. shutdown PulseView (closing all session tabs).
 .TP

--- a/pv/views/trace/view.hpp
+++ b/pv/views/trace/view.hpp
@@ -423,6 +423,8 @@ private:
 	void update_view_range_metaobject() const;
 	void update_hover_point();
 
+	void h_scroll_view_fullpage(int direction);
+
 public:
 	void row_item_appearance_changed(bool label, bool content);
 	void time_item_appearance_changed(bool label, bool content);
@@ -437,6 +439,8 @@ private Q_SLOTS:
 	void on_zoom_out_shortcut_triggered();
 	void on_scroll_to_start_shortcut_triggered();
 	void on_scroll_to_end_shortcut_triggered();
+	void on_h_scroll_view_left_triggered();
+	void on_h_scroll_view_right_triggered();
 
 	void h_scroll_value_changed(int value);
 	void v_scroll_value_changed();
@@ -509,6 +513,8 @@ private:
 	QShortcut *home_shortcut_, *end_shortcut_;
 	QShortcut *grab_ruler_left_shortcut_, *grab_ruler_right_shortcut_;
 	QShortcut *cancel_grab_shortcut_;
+	QShortcut *scroll_view_left_;
+	QShortcut *scroll_view_right_;
 
 	mutable mutex signal_mutex_;
 	vector< shared_ptr<Signal> > signals_;

--- a/pv/views/trace/view.hpp
+++ b/pv/views/trace/view.hpp
@@ -442,6 +442,7 @@ private Q_SLOTS:
 	void on_h_scroll_view_left_triggered();
 	void on_h_scroll_view_right_triggered();
 	void on_bitmap_screenshot_triggered();
+	void on_svg_screenshot_triggered();
 
 	void h_scroll_value_changed(int value);
 	void v_scroll_value_changed();
@@ -517,6 +518,7 @@ private:
 	QShortcut *scroll_view_left_;
 	QShortcut *scroll_view_right_;
 	QShortcut *bitmap_screenshot_;
+	QShortcut *svg_screenshot_;
 
 	mutable mutex signal_mutex_;
 	vector< shared_ptr<Signal> > signals_;

--- a/pv/views/trace/view.hpp
+++ b/pv/views/trace/view.hpp
@@ -441,6 +441,7 @@ private Q_SLOTS:
 	void on_scroll_to_end_shortcut_triggered();
 	void on_h_scroll_view_left_triggered();
 	void on_h_scroll_view_right_triggered();
+	void on_bitmap_screenshot_triggered();
 
 	void h_scroll_value_changed(int value);
 	void v_scroll_value_changed();
@@ -515,6 +516,7 @@ private:
 	QShortcut *cancel_grab_shortcut_;
 	QShortcut *scroll_view_left_;
 	QShortcut *scroll_view_right_;
+	QShortcut *bitmap_screenshot_;
 
 	mutable mutex signal_mutex_;
 	vector< shared_ptr<Signal> > signals_;


### PR DESCRIPTION
The changes/commits in this branch introduce three new keyboard shortcuts:

* <kbd>CTRL</kbd> + <kbd>m</kbd> /  <kbd>CTRL</kbd> + <kbd>n</kbd>

> Scroll forward or backward (right or left) in time (horizontally) for the
> entire width of the capture, currently shown in the PulseView window viewport,
> according to current zoom settings (could be called a "full-page" scroll, by
> analogy with printable document viewers)

* <kbd>CTRL</kbd> + <kbd>b</kbd>

> Save a bitmap screen capture (screenshot) of only the ruler and the viewport,
> currently shown in the PulseView window; which allows these screenshots to be
> stitched together horizontally afterwards, if they are obtained through a
> "full-page" scroll (note: not pixel-perfect). Screenshots are saved with a
> filename of 'pulseview_yyyyMMdd_hhmmss.png' (UTC timestamp), in the
> temporary directory of the OS.

With these shortcuts, one can export a series of screenshots at arbitrary zoom level, and then stitch them together, using e.g.:

```bash
magick montage pulseview_* -tile x1 -geometry +0+0 pulseout.png
```

For an example, see https://imgur.com/a/quqLdPE  - here the old [examples/ad5258_read_once_write_continuously_triangle.sr](https://sigrok.org/gitweb/?p=sigrok-dumps.git;a=blob;f=i2c/potentiometer/analog_devices_ad5258/ad5258_read_once_write_continuously_triangle.sr;) was loaded, the analog channel was interpreted as digital, and UART decoder was ran on it (a useless example in reality, however it tests most of the graphics we might expect to find in PulseView). (EDIT: for this kind of operation, one probably wants to enable PulseView Settings/Decoders/Always show all rows, even if no annotation is visible)