### PR TITLE
Save dialog: Fix cancellation

### DIFF
--- a/pv/dialogs/storeprogress.cpp
+++ b/pv/dialogs/storeprogress.cpp
@@ -50,6 +50,7 @@ StoreProgress::StoreProgress(const QString &file_name,
 		this, SLOT(on_progress_updated()));
 	connect(&session_, SIGNAL(store_successful()),
 		&session, SLOT(on_data_saved()));
+	connect(this, SIGNAL(canceled()), this, SLOT(on_cancel()));
 
 	// Since we're not setting any progress in case of an error, the dialog
 	// will pop up after the minimumDuration time has been reached - 4000 ms
@@ -115,6 +116,11 @@ void StoreProgress::on_progress_updated()
 		if (!err.isEmpty() && !showing_error_)
 			show_error();
 	}
+}
+
+void StoreProgress::on_cancel()
+{
+	session_.cancel();
 }
 
 }  // namespace dialogs

--- a/pv/dialogs/storeprogress.hpp
+++ b/pv/dialogs/storeprogress.hpp
@@ -62,6 +62,7 @@ private:
 
 private Q_SLOTS:
 	void on_progress_updated();
+	void on_cancel();
 
 private:
 	pv::StoreSession session_;


### PR DESCRIPTION
Without the fix cancellation of save data does not work

I am not familiar with Qt. 
If you have a better solution I am happy to close this PR, e.g. I could not get it working, to connect signal 'canceled' directly to slot 'cancel' in session_ 

How to reproduce:
	1. Start PV with demo device and generate sufficient data, e.g. demo device 1GSa/s, 10MSa
	2. Save data (should take at least 30s) and try to cancel saving
	3. PV continues saving data and dialog reappears after next progress update

