### PR TITLE
Fix broken build due to C++ template behind C linkage

### DIFF
--- a/pv/data/decode/annotation.cpp
+++ b/pv/data/decode/annotation.cpp
@@ -17,9 +17,7 @@
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
-extern "C" {
 #include <libsigrokdecode/libsigrokdecode.h>
-}
 
 #include <cassert>
 #include <vector>

--- a/pv/views/trace/decodetrace.cpp
+++ b/pv/views/trace/decodetrace.cpp
@@ -17,9 +17,7 @@
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
-extern "C" {
 #include <libsigrokdecode/libsigrokdecode.h>
-}
 
 #include <limits>
 #include <mutex>


### PR DESCRIPTION
glib/gatomic.h since 2.68 includes type_traits, which causes a compilation
error:
In file included from /usr/include/glib-2.0/glib/gatomic.h:31,
                 from /usr/include/glib-2.0/glib/gthread.h:32,
                 from /usr/include/glib-2.0/glib/gasyncqueue.h:32,
                 from /usr/include/glib-2.0/glib.h:32,
                 from /usr/include/libsigrokdecode/libsigrokdecode.h:25,
                 from /home/abuild/rpmbuild/BUILD/pulseview-0.4.2/pv/data/decode/annotation.cpp:21:
/usr/include/c++/10/type_traits:2308:3: error: template with C linkage
2308 |   template<typename _CTp, typename _Rp>

As libsigrokdecode.h declares extern C linkage itself where necessary,
remove it from pulseviews include statements from the last two occasions.