### PR TITLE
Move C linking below standard includes to fix build with latest glibc

### DIFF
--- a/pv/data/decode/annotation.cpp
+++ b/pv/data/decode/annotation.cpp
@@ -17,16 +17,16 @@
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
-extern "C" {
-#include <libsigrokdecode/libsigrokdecode.h>
-}
-
 #include <cassert>
 #include <vector>
 
 #include <pv/data/decode/annotation.hpp>
 #include <pv/data/decode/decoder.hpp>
 #include "pv/data/decode/rowdata.hpp"
+
+extern "C" {
+#include <libsigrokdecode/libsigrokdecode.h>
+}
 
 using std::vector;
 


### PR DESCRIPTION
Fixes:
| In file included from /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/pulseview/0.4.2+gitAUTOINC+89b7b94a04-r0/recipe-sysroot/usr/include/glib-2.0/glib/gatomic.h:31,
|                  from /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/pulseview/0.4.2+gitAUTOINC+89b7b94a04-r0/recipe-sysroot/usr/include/glib-2.0/glib/gthread.h:32,
|                  from /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/pulseview/0.4.2+gitAUTOINC+89b7b94a04-r0/recipe-sysroot/usr/include/glib-2.0/glib/gasyncqueue.h:32,
|                  from /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/pulseview/0.4.2+gitAUTOINC+89b7b94a04-r0/recipe-sysroot/usr/include/glib-2.0/glib.h:32,
|                  from /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/pulseview/0.4.2+gitAUTOINC+89b7b94a04-r0/recipe-sysroot/usr/include/libsigrokdecode/libsigrokdecode.h:25,
|                  from /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/pulseview/0.4.2+gitAUTOINC+89b7b94a04-r0/git/pv/data/decode/annotation.cpp:21:
| /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/pulseview/0.4.2+gitAUTOINC+89b7b94a04-r0/recipe-sysroot/usr/include/c++/10.3.0/type_traits:56:3: error: template with C linkage
|    56 |   template<typename _Tp, _Tp __v>
|       |   ^~~~~~~~

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>