### PR TITLE
Build: Ensure QT plugin imports are only done when compiling statically

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -70,8 +70,10 @@
 
 #ifdef _WIN32
 #include <QtPlugin>
+#ifdef QT_STATIC
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
 Q_IMPORT_PLUGIN(QSvgPlugin)
+#endif
 #endif
 
 using std::exception;


### PR DESCRIPTION
Getting PulseView to build on MinGW with shared imports requires causing plugin imports to only occur on static builds as shared builds will automatically import them as required.