### PR TITLE
Add default file names and extensions to Save dialogs

### DIFF
--- a/pv/toolbars/mainbar.cpp
+++ b/pv/toolbars/mainbar.cpp
@@ -629,7 +629,6 @@ void MainBar::export_file(shared_ptr<OutputFormat> format, bool selection_only, 
 	session_.stop_capture();
 
 	QSettings settings;
-	const QString dir = settings.value(SettingSaveDirectory).toString();
 
 	pair<uint64_t, uint64_t> sample_range;
 
@@ -680,8 +679,12 @@ void MainBar::export_file(shared_ptr<OutputFormat> format, bool selection_only, 
 			tr("All Files"));
 
 	// Show the file dialog
-	if (file_name.isEmpty())
+	if (file_name.isEmpty()) {
+		QString dir = settings.value(SettingSaveDirectory).toString() + tr("/new_session");
+		if (!exts.empty())
+			dir += "." + QString::fromStdString(exts[0]);
 		file_name = QFileDialog::getSaveFileName(this, tr("Save File"), dir, filter);
+	}
 
 	if (file_name.isEmpty())
 		return;
@@ -855,7 +858,7 @@ void MainBar::on_actionSaveSelectionAs_triggered()
 void MainBar::on_actionSaveSetup_triggered()
 {
 	QSettings settings;
-	const QString dir = settings.value(SettingSaveDirectory).toString();
+	const QString dir = settings.value(SettingSaveDirectory).toString() + tr("/new_session_setup.pvs");
 
 	const QString file_name = QFileDialog::getSaveFileName(
 		this, tr("Save File"), dir, tr(


### PR DESCRIPTION
Hello,

The current implementation of PulseView doesn't propose a default filename when a user tries to save a session or session's setup.
If a user is not aware of the extension he is supposed to use, it has no way to find it easily.
E.g. 
![image](https://user-images.githubusercontent.com/1215136/151677185-8393bdea-8c9c-4829-a26a-5f7e2112f64f.png)
I.e. `.sr` is not mentioned as an extension anywhere in the dialog.
The change gives a user a default file name with extension, which should minimize confusion.
E.g.:
![image](https://user-images.githubusercontent.com/1215136/151677214-3e4aa4d2-36b3-4a88-8e25-ad2cfab5f420.png)

