### PR TITLE
pv::views::trace: set a lower MinScale

### DIFF
--- a/pv/views/trace/view.cpp
+++ b/pv/views/trace/view.cpp
@@ -92,7 +92,7 @@ namespace views {
 namespace trace {
 
 const Timestamp View::MaxScale("1e9");
-const Timestamp View::MinScale("1e-12");
+const Timestamp View::MinScale("1e-14");
 
 const int View::MaxScrollValue = INT_MAX / 2;
 


### PR DESCRIPTION
This allows to view smaller scale (ps scale) signals, e.g. from simulation.