### PR TITLE
Include <memory> so we don't get error at compile time.

### DIFF
--- a/pv/data/segment.hpp
+++ b/pv/data/segment.hpp
@@ -24,6 +24,7 @@
 #include "pv/util.hpp"
 
 #include <atomic>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <deque>


### PR DESCRIPTION
`shared_ptr` requires `<memory>` and it fails to build mingw on my archlinux machine using gcc `12.2.0`

Example build failure:
```
  In file included from /home/paul/sigrok-util/cross-compile/mingw/build_release_64/pulseview/pv/data/segment.cpp:21:
  /home/paul/sigrok-util/cross-compile/mingw/build_release_64/pulseview/pv/data/segment.hpp:130:14: error: 'shared_ptr' in namespace 'std' does not name a template type
    130 | typedef std::shared_ptr<pv::data::Segment> SharedPtrToSegment;
        |              ^~~~~~~~~~
  /home/paul/sigrok-util/cross-compile/mingw/build_release_64/pulseview/pv/data/segment.hpp:32:1: note: 'std::shared_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
     31 | #include <QObject>
    +++ |+#include <memory>
     32 |
```