### PR TITLE
Prevent duplicate math/decoder signals when restoring a session

### DIFF
--- a/pv/session.cpp
+++ b/pv/session.cpp
@@ -382,6 +382,20 @@ void Session::restore_setup(QSettings &settings)
 		settings.endGroup();
 	}
 
+	// Remove generated signals and decoders
+	for (shared_ptr<data::SignalBase> base : vector< shared_ptr<data::SignalBase> >(signalbases_)) {
+#ifdef ENABLE_DECODE
+		if (base->is_decode_signal()) {
+			shared_ptr<data::DecodeSignal> ds = dynamic_pointer_cast<data::DecodeSignal>(base);
+			assert(ds);
+			remove_decode_signal(ds);
+		} else
+#endif
+		if (base->is_generated()) {
+			remove_generated_signal(base);
+		}
+	}
+
 	// Restore generated signals
 	int gen_signal_count = settings.value("generated_signals").toInt();
 

--- a/pv/toolbars/mainbar.cpp
+++ b/pv/toolbars/mainbar.cpp
@@ -866,6 +866,7 @@ void MainBar::on_actionSaveSetup_triggered()
 		return;
 
 	QSettings settings_storage(file_name, QSettings::IniFormat);
+	settings_storage.clear();
 	session_.save_setup(settings_storage);
 }
 


### PR DESCRIPTION
I added some changes to remove all old math/decoder signals when a session is restored from a file.
Also, overwriting a session setup file, old entries in the file are deleted.