### PR TITLE
Fix the default item in the language combobox

### DIFF
--- a/pv/dialogs/settings.cpp
+++ b/pv/dialogs/settings.cpp
@@ -220,7 +220,7 @@ QWidget *Settings::get_general_settings_form(QWidget *parent) const
 	QComboBox *language_cb = new QComboBox();
 	Application* a = qobject_cast<Application*>(QApplication::instance());
 
-	QString current_language = settings.value(GlobalSettings::Key_General_Language).toString();
+	QString current_language = settings.value(GlobalSettings::Key_General_Language, "en").toString();
 	for (const QString& language : a->get_languages()) {
 		const QLocale locale = QLocale(language);
 		const QString desc = locale.languageToString(locale.language());


### PR DESCRIPTION
If the language is not set, the default language will be English, but the combobox will show "German"(The first item in language combobox) 
This is because the current_language will set to "" if the language is not set, and it doesn't match the default language "en"