### PR TITLE
UI: Move shortcuts to Qt StandardKeys constants

### DIFF
--- a/pv/mainwindow.cpp
+++ b/pv/mainwindow.cpp
@@ -547,14 +547,10 @@ void MainWindow::setup_ui()
 	session_selector_.setCornerWidget(static_tab_widget_, Qt::TopLeftCorner);
 	session_selector_.setTabsClosable(true);
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-	close_application_shortcut_ = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q), this, SLOT(close()));
-	close_current_tab_shortcut_ = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_W), this, SLOT(on_close_current_tab()));
-#else
-	close_application_shortcut_ = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), this, SLOT(close()));
-	close_current_tab_shortcut_ = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_W), this, SLOT(on_close_current_tab()));
-#endif
+	close_application_shortcut_ = new QShortcut(QKeySequence::Quit, this, SLOT(close()));
 	close_application_shortcut_->setAutoRepeat(false);
+
+	close_current_tab_shortcut_ = new QShortcut(QKeySequence::Close, this, SLOT(on_close_current_tab()));
 
 	connect(new_session_button_, SIGNAL(clicked(bool)),
 		this, SLOT(on_new_session_clicked()));

--- a/pv/toolbars/mainbar.cpp
+++ b/pv/toolbars/mainbar.cpp
@@ -130,11 +130,7 @@ MainBar::MainBar(Session &session, QWidget *parent, pv::views::trace::View *view
 	action_open_->setText(tr("&Open..."));
 	action_open_->setIcon(QIcon::fromTheme("document-open",
 		QIcon(":/icons/document-open.png")));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-	action_open_->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_O));
-#else
-	action_open_->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_O));
-#endif
+	action_open_->setShortcut(QKeySequence::Open);
 	connect(action_open_, SIGNAL(triggered(bool)),
 		this, SLOT(on_actionOpen_triggered()));
 
@@ -145,11 +141,7 @@ MainBar::MainBar(Session &session, QWidget *parent, pv::views::trace::View *view
 	action_save_->setText(tr("&Save..."));
 	action_save_->setIcon(QIcon::fromTheme("document-save-as",
 		QIcon(":/icons/document-save-as.png")));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-	action_save_->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_S));
-#else
-	action_save_->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_S));
-#endif
+	action_save_->setShortcut(QKeySequence::Save);
 	connect(action_save_, SIGNAL(triggered(bool)),
 		this, SLOT(on_actionSave_triggered()));
 


### PR DESCRIPTION
This patch uses the Qt provided constants for the quit, close, open and save keyboard shortcuts. This removes few instances of Qt version specific code.

Only functional difference of this patch is that on windows the quit shortcut of ctrl-q will no longer work, instead relying on the platform standard alt-f4.