### PR TITLE
Bugfix: Recalculate scale when restoring div height

### DIFF
--- a/pv/views/trace/analogsignal.cpp
+++ b/pv/views/trace/analogsignal.cpp
@@ -177,6 +177,7 @@ void AnalogSignal::restore_settings(std::map<QString, QVariant> settings)
 		div_height_ = settings["div_height"].toInt();
 
 		update_logic_level_offsets();
+		update_scale();
 
 		if ((div_height_ != old_height) && owner_) {
 			// Call order is important, otherwise the lazy event handler won't work


### PR DESCRIPTION
When restoring analog signal settings from a *.pvs file changes the div height, the vertical scale must be recalculated. Otherwise, the signal is scaled as if the div height had not changed, until a UI event triggers recalculation.