### PR TITLE
trace: fix crash on empty channel name in popup form

### DIFF
--- a/pv/views/trace/trace.cpp
+++ b/pv/views/trace/trace.cpp
@@ -442,7 +442,8 @@ void Trace::on_popup_closed()
 void Trace::on_nameedit_changed(const QString &name)
 {
 	/* This event handler notifies SignalBase that the name changed */
-	base_->set_name(name);
+	if(!name.isEmpty())
+		base_->set_name(name);
 }
 
 void Trace::on_coloredit_changed(const QColor &color)


### PR DESCRIPTION
sr_dev_channel_name_set returns SR_ERR_ARG when a channel name is empty and pulseview crashes once user deletes all characters from a channel name in trace popup form.

This patch forbids to set empty channel name and keeps last non-empty name provided by user.