### PR TITLE
Fix time error in ruler popup menu commands

### DIFF
--- a/pv/views/trace/ruler.cpp
+++ b/pv/views/trace/ruler.cpp
@@ -146,6 +146,9 @@ void Ruler::contextMenuEvent(QContextMenuEvent *event)
 	if (event->isAccepted())
 		return;
 
+	// Save the place of the click in the popup menu
+	// so that it can be used when a popup menu action is selected
+	// and needs to know the mouse position in the ruler
 	context_menu_x_pos_ = event->pos().x();
 
 	QMenu *const menu = new QMenu(this);
@@ -399,12 +402,12 @@ void Ruler::invalidate_tick_position_cache()
 
 void Ruler::on_createMarker()
 {
-	hover_item_ = view_.add_flag(get_absolute_time_from_x_pos(mouse_down_point_.x()));
+	hover_item_ = view_.add_flag(get_absolute_time_from_x_pos(context_menu_x_pos_));
 }
 
 void Ruler::on_setZeroPosition()
 {
-	view_.set_zero_position(get_absolute_time_from_x_pos(mouse_down_point_.x()));
+	view_.set_zero_position(get_absolute_time_from_x_pos(context_menu_x_pos_));
 }
 
 void Ruler::on_resetZeroPosition()

--- a/pv/views/trace/ruler.hpp
+++ b/pv/views/trace/ruler.hpp
@@ -196,6 +196,9 @@ private:
 
 	shared_ptr<TimeItem> hover_item_;
 
+	/**
+	 * @brief Save the place (x only) where the user has clicked to open the popup menu
+	 */
 	uint32_t context_menu_x_pos_;
 };
 


### PR DESCRIPTION
When using one of the 2 commands of the ruler popup menu that refers to the click position (either **Create Marker** or **Set as Zero Point**), the result is completely wrong. Huge time error occurs.

This fixes this issue which is caused by the location of the mouse erased when mouse button goes up which occurs way before the command is executed. It appears that it exists another variable that already memorize the click position until next click. Using this long-term variable instead of short-term one fixes the issue.