### PR TITLE
Sipeed SLogic analyzer fixes

### DIFF
--- a/pv/binding/device.cpp
+++ b/pv/binding/device.cpp
@@ -74,7 +74,7 @@ Device::Device(shared_ptr<sigrok::Configurable> configurable) :
 
 			// Ignore common read-only keys
 			if ((key->id() == SR_CONF_CONTINUOUS) || (key->id() == SR_CONF_TRIGGER_MATCH) ||
-			    (key->id() == SR_CONF_CONN) || (key->id() == SR_CONF_SERIALCOMM) || (key->id() == SR_CONF_NUM_LOGIC_CHANNELS) ||
+			    (key->id() == SR_CONF_CONN) || (key->id() == SR_CONF_SERIALCOMM) ||
 			    (key->id() == SR_CONF_NUM_ANALOG_CHANNELS) || (key->id() == SR_CONF_SESSIONFILE) || (key->id() == SR_CONF_CAPTUREFILE) ||
 			    (key->id() == SR_CONF_CAPTURE_UNITSIZE))
 				continue;
@@ -115,6 +115,7 @@ Device::Device(shared_ptr<sigrok::Configurable> configurable) :
 		case SR_CONF_CLOCK_EDGE:
 		case SR_CONF_DATA_SOURCE:
 		case SR_CONF_EXTERNAL_CLOCK_SOURCE:
+		case SR_CONF_NUM_LOGIC_CHANNELS:
 			bind_enum(descr, "", key, capabilities, get, set);
 			break;
 

--- a/pv/popups/channels.cpp
+++ b/pv/popups/channels.cpp
@@ -181,6 +181,7 @@ void Channels::set_all_channels(bool set)
 	}
 
 	updating_channels_ = false;
+	config_changed();
 }
 
 void Channels::enable_channels_conditionally(
@@ -200,6 +201,7 @@ void Channels::enable_channels_conditionally(
 	}
 
 	updating_channels_ = false;
+	config_changed();
 }
 
 void Channels::disable_channels_conditionally(
@@ -219,6 +221,7 @@ void Channels::disable_channels_conditionally(
 	}
 
 	updating_channels_ = false;
+	config_changed();
 }
 
 void Channels::populate_group(shared_ptr<ChannelGroup> group,
@@ -380,6 +383,7 @@ void Channels::on_channel_checked(QWidget *widget)
 	assert(s);
 
 	s->set_enabled(check_box->isChecked());
+	config_changed();
 }
 
 void Channels::enable_all_channels()

--- a/pv/popups/channels.hpp
+++ b/pv/popups/channels.hpp
@@ -81,6 +81,9 @@ private:
 
 	void showEvent(QShowEvent *event);
 
+Q_SIGNALS:
+	void config_changed();
+
 private Q_SLOTS:
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	void on_channel_checked(QObject *widget);

--- a/pv/toolbars/mainbar.cpp
+++ b/pv/toolbars/mainbar.cpp
@@ -812,6 +812,9 @@ void MainBar::on_config_changed()
 
 	commit_sample_count();
 	commit_sample_rate();
+	for (auto& signal: session_.signalbases()) {
+		signal->enabled_changed(signal->enabled());
+	}
 }
 
 void MainBar::on_actionNewView_triggered(QAction* action)

--- a/pv/toolbars/mainbar.cpp
+++ b/pv/toolbars/mainbar.cpp
@@ -552,6 +552,7 @@ void MainBar::update_device_config_widgets()
 	// Update the channels popup
 	Channels *const channels = new Channels(session_, this);
 	channels_button_.set_popup(channels);
+	QObject::connect(channels, &Channels::config_changed, this, &MainBar::on_config_changed);
 
 	// Update supported options.
 	sample_count_supported_ = false;


### PR DESCRIPTION
Various improvements for https://github.com/sigrokproject/libsigrok/pull/275 :
* unblacklist `SR_CONF_NUM_LOGIC_CHANNELS` property
* immediately refresh visible traces on device settings change since `SR_CONF_NUM_LOGIC_CHANNELS` directly impact on this
* update topbar comboboxes on channel selection/deselection since device could have different samplerates depending on enabled channels
