### PR TITLE
Logic channel color sequencing

### DIFF
--- a/l10n/de.ts
+++ b/l10n/de.ts
@@ -546,6 +546,11 @@ A human-readable form has been saved to disk and was written to the log. You may
         <translation>Standardgröße von Logikkanälen</translation>
     </message>
     <message>
+        <location filename="../pv/dialogs/settings.cpp" line="390"/>
+        <source>Logic channel color offset</source>
+        <translation>Farbe des Logikkanälen</translation>
+    </message>
+    <message>
         <location filename="../pv/dialogs/settings.cpp" line="405"/>
         <source>Allow configuration of &amp;initial signal state</source>
         <translation>&amp;Initialzustände von Signalen konfigurierbar machen</translation>

--- a/l10n/es_MX.ts
+++ b/l10n/es_MX.ts
@@ -597,6 +597,11 @@ Se guardó un formulario legible para humanosen el disco y fue escrito en el log
         <translation>Altura de trazo lógico por defecto</translation>
     </message>
     <message>
+        <location filename="../pv/dialogs/settings.cpp" line="408"/>
+        <source>Logic channel color offset</source>
+        <translation>Color del canal lógico</translation>
+    </message>
+    <message>
         <location filename="../pv/dialogs/settings.cpp" line="423"/>
         <source>Allow configuration of &amp;initial signal state</source>
         <translation>Permitir configuración de estado de señal &amp;inicial</translation>

--- a/l10n/ja_jp.ts
+++ b/l10n/ja_jp.ts
@@ -579,6 +579,11 @@ A human-readable form has been saved to disk and was written to the log. You may
         <translation>デフォルトのロジックトレースの高さ</translation>
     </message>
     <message>
+        <location filename="../pv/dialogs/settings.cpp" line="399"/>
+        <source>Logic channel color offset</source>
+        <translation>ロジックチャンネルの色</translation>
+    </message>
+    <message>
         <location filename="../pv/dialogs/settings.cpp" line="414"/>
         <source>Allow configuration of &amp;initial signal state</source>
         <translation>初期信号状態の構成を許可する(&amp;i)</translation>

--- a/l10n/zh_cn.ts
+++ b/l10n/zh_cn.ts
@@ -579,6 +579,11 @@ A human-readable form has been saved to disk and was written to the log. You may
         <translation>逻辑通道垂直高度</translation>
     </message>
     <message>
+        <location filename="../pv/dialogs/settings.cpp" line="404"/>
+        <source>Logic channel color offset</source>
+        <translation>逻辑通道颜色</translation>
+    </message>
+    <message>
         <location filename="../pv/dialogs/settings.cpp" line="419"/>
         <source>Allow configuration of &amp;initial signal state</source>
         <translation>允许配置初始信号状态</translation>

--- a/pv/data/signalbase.cpp
+++ b/pv/data/signalbase.cpp
@@ -30,6 +30,7 @@
 
 #include <extdef.h>
 #include <pv/session.hpp>
+#include <pv/globalsettings.hpp>
 #include <pv/binding/decoder.hpp>
 
 using std::dynamic_pointer_cast;
@@ -132,6 +133,9 @@ SignalBase::SignalBase(shared_ptr<sigrok::Channel> channel, ChannelType channel_
 		set_index(channel_->index());
 	}
 
+	GlobalSettings settings;
+	int color_offset = settings.value(GlobalSettings::Key_View_LogicColorOffset).toInt();
+
 	connect(&delayed_conversion_starter_, SIGNAL(timeout()),
 		this, SLOT(on_delayed_conversion_start()));
 	delayed_conversion_starter_.setSingleShot(true);
@@ -140,7 +144,7 @@ SignalBase::SignalBase(shared_ptr<sigrok::Channel> channel, ChannelType channel_
 	// Only logic and analog SR channels can have their colors auto-set
 	// because for them, we have an index that can be used
 	if (channel_type == LogicChannel)
-		set_color(LogicSignalColors[index() % countof(LogicSignalColors)]);
+		set_color(LogicSignalColors[(index() + color_offset) % countof(LogicSignalColors)]);
 	else if (channel_type == AnalogChannel)
 		set_color(AnalogSignalColors[index() % countof(AnalogSignalColors)]);
 }

--- a/pv/dialogs/settings.cpp
+++ b/pv/dialogs/settings.cpp
@@ -399,6 +399,14 @@ QWidget *Settings::get_view_settings_form(QWidget *parent) const
 		SLOT(on_view_defaultLogicHeight_changed(int)));
 	trace_view_layout->addRow(tr("Default logic trace height"), default_logic_height_sb);
 
+	QSpinBox *logic_color_offset_sb = new QSpinBox();
+	logic_color_offset_sb->setRange(0, 10);
+	logic_color_offset_sb->setValue(
+		settings.value(GlobalSettings::Key_View_LogicColorOffset).toInt());
+	connect(logic_color_offset_sb, SIGNAL(valueChanged(int)), this,
+		SLOT(on_view_logicColorOffset_changed(int)));
+	trace_view_layout->addRow(tr("Logic channel color offset"), logic_color_offset_sb);
+
 	return form;
 }
 
@@ -803,6 +811,12 @@ void Settings::on_view_defaultLogicHeight_changed(int value)
 {
 	GlobalSettings settings;
 	settings.setValue(GlobalSettings::Key_View_DefaultLogicHeight, value);
+}
+
+void Settings::on_view_logicColorOffset_changed(int value)
+{
+	GlobalSettings settings;
+	settings.setValue(GlobalSettings::Key_View_LogicColorOffset, value);
 }
 
 #ifdef ENABLE_DECODE

--- a/pv/dialogs/settings.hpp
+++ b/pv/dialogs/settings.hpp
@@ -80,6 +80,7 @@ private Q_SLOTS:
 	void on_view_conversionThresholdDispMode_changed(int state);
 	void on_view_defaultDivHeight_changed(int value);
 	void on_view_defaultLogicHeight_changed(int value);
+	void on_view_logicColorOffset_changed(int value);
 #ifdef ENABLE_DECODE
 	void on_dec_initialStateConfigurable_changed(int state);
 	void on_dec_exportFormat_changed(const QString &text);

--- a/pv/globalsettings.cpp
+++ b/pv/globalsettings.cpp
@@ -66,6 +66,7 @@ const QString GlobalSettings::Key_View_ShowAnalogMinorGrid = "View_ShowAnalogMin
 const QString GlobalSettings::Key_View_ConversionThresholdDispMode = "View_ConversionThresholdDispMode";
 const QString GlobalSettings::Key_View_DefaultDivHeight = "View_DefaultDivHeight";
 const QString GlobalSettings::Key_View_DefaultLogicHeight = "View_DefaultLogicHeight";
+const QString GlobalSettings::Key_View_LogicColorOffset = "View_LogicColorOffset";
 const QString GlobalSettings::Key_View_ShowHoverMarker = "View_ShowHoverMarker";
 const QString GlobalSettings::Key_View_KeepRulerItemSelected = "View_KeepRulerItemSelected";
 const QString GlobalSettings::Key_View_SnapDistance = "View_SnapDistance";
@@ -148,6 +149,10 @@ void GlobalSettings::set_defaults_where_needed()
 
 	if (!contains(Key_View_DefaultLogicHeight))
 		setValue(Key_View_DefaultLogicHeight,
+		2 * QFontMetrics(QApplication::font()).height());
+
+	if (!contains(Key_View_LogicColorOffset))
+		setValue(Key_View_LogicColorOffset,
 		2 * QFontMetrics(QApplication::font()).height());
 
 	if (!contains(Key_View_ShowHoverMarker))

--- a/pv/globalsettings.cpp
+++ b/pv/globalsettings.cpp
@@ -152,8 +152,7 @@ void GlobalSettings::set_defaults_where_needed()
 		2 * QFontMetrics(QApplication::font()).height());
 
 	if (!contains(Key_View_LogicColorOffset))
-		setValue(Key_View_LogicColorOffset,
-		2 * QFontMetrics(QApplication::font()).height());
+		setValue(Key_View_LogicColorOffset, 0);
 
 	if (!contains(Key_View_ShowHoverMarker))
 		setValue(Key_View_ShowHoverMarker, true);

--- a/pv/globalsettings.hpp
+++ b/pv/globalsettings.hpp
@@ -71,6 +71,7 @@ public:
 	static const QString Key_View_ConversionThresholdDispMode;
 	static const QString Key_View_DefaultDivHeight;
 	static const QString Key_View_DefaultLogicHeight;
+	static const QString Key_View_LogicColorOffset;
 	static const QString Key_View_ShowHoverMarker;
 	static const QString Key_View_KeepRulerItemSelected;
 	static const QString Key_View_SnapDistance;


### PR DESCRIPTION
I humbly beseech the maintainers that be, that they might accept this pull request. I know this might seem pedantic, however, most manufacturers of ribbon cable in the last 20 years start with brown, red ... with black next to white at the other side of the cable (for 10 wire, or 40 wire ribbon cable).

This pull request adds an option to the view settings to change the color offset for the logical channels. This allows a user to set the first color used for channels to be brown (or some other color) by default (instead of black)

Setting a value of "1" for the "Logic color offset" assigns brown as the color for channel 0, red as channel 1, etc... This has the following benefits:
1. It better matches the most common manufacturing sequencing for colored ribbon cables.
2. This works better with the cheapest available [logic analyzers](https://www.sparkfun.com/usb-logic-analyzer-24mhz-8-channel.html). These are very common and the GND signals are placed in positions 9 and 10.  If position 10 was black that would equate to the GND return for most of these cheap analyzers.

The default for the color offset is: "0", allowing for the traditional look of pulseview to remain unchanged and work well with the Saleae logic analyzers that use black for channel 0.

I did my best with the translations for German, Spanish, Japanese, and Chinese.  Those will certainly need a review.