### PR TITLE
Bugfix: Signal min/max in UI

### DIFF
--- a/pv/data/signalbase.cpp
+++ b/pv/data/signalbase.cpp
@@ -884,10 +884,9 @@ void SignalBase::stop_conversion()
 
 void SignalBase::on_samples_cleared()
 {
-	if (converted_data_ && (converted_data_->get_segment_count() > 0)) {
+	if (converted_data_ && (converted_data_->get_segment_count() > 0))
 		converted_data_->clear();
-		samples_cleared();
-	}
+	samples_cleared();
 }
 
 void SignalBase::on_samples_added(SharedPtrToSegment segment, uint64_t start_sample,

--- a/pv/views/trace/analogsignal.cpp
+++ b/pv/views/trace/analogsignal.cpp
@@ -943,6 +943,12 @@ void AnalogSignal::on_setting_changed(const QString &key, const QVariant &value)
 	}
 }
 
+void AnalogSignal::on_samples_cleared()
+{
+	signal_min_ = 0;
+	signal_max_ = 0;
+}
+
 void AnalogSignal::on_min_max_changed(float min, float max)
 {
 	if (autoranging_)

--- a/pv/views/trace/analogsignal.cpp
+++ b/pv/views/trace/analogsignal.cpp
@@ -104,7 +104,9 @@ AnalogSignal::AnalogSignal(pv::Session &session, shared_ptr<data::SignalBase> ba
 	neg_vdivs_(1),
 	resolution_(0),
 	display_type_(DisplayAnalog),
-	autoranging_(true)
+	autoranging_(true),
+	signal_min_(0),
+	signal_max_(0)
 {
 	axis_pen_ = AxisPen;
 

--- a/pv/views/trace/analogsignal.cpp
+++ b/pv/views/trace/analogsignal.cpp
@@ -98,15 +98,15 @@ const int AnalogSignal::InfoTextMarginBottom = 5;
 
 AnalogSignal::AnalogSignal(pv::Session &session, shared_ptr<data::SignalBase> base) :
 	LogicSignal(session, base),
+	signal_min_(0),
+	signal_max_(0),
 	value_at_hover_pos_(std::numeric_limits<float>::quiet_NaN()),
 	scale_index_(4), // 20 per div
 	pos_vdivs_(1),
 	neg_vdivs_(1),
 	resolution_(0),
 	display_type_(DisplayAnalog),
-	autoranging_(true),
-	signal_min_(0),
-	signal_max_(0)
+	autoranging_(true)
 {
 	axis_pen_ = AxisPen;
 

--- a/pv/views/trace/analogsignal.hpp
+++ b/pv/views/trace/analogsignal.hpp
@@ -151,6 +151,7 @@ protected:
 private Q_SLOTS:
 	virtual void on_setting_changed(const QString &key, const QVariant &value);
 
+	virtual void on_samples_cleared() override;
 	void on_min_max_changed(float min, float max);
 
 	void on_pos_vdivs_changed(int vdivs);

--- a/pv/views/trace/trace.cpp
+++ b/pv/views/trace/trace.cpp
@@ -65,6 +65,8 @@ Trace::Trace(shared_ptr<data::SignalBase> signal) :
 		this, SLOT(on_color_changed(const QColor&)));
 	connect(signal.get(), SIGNAL(error_message_changed(const QString&)),
 		this, SLOT(on_error_message_changed(const QString&)));
+	connect(signal.get(), SIGNAL(samples_cleared()),
+		this, SLOT(on_samples_cleared()));
 
 	GlobalSettings::add_change_handler(this);
 
@@ -437,6 +439,10 @@ void Trace::on_popup_closed()
 {
 	popup_ = nullptr;
 	popup_form_ = nullptr;
+}
+
+void Trace::on_samples_cleared()
+{
 }
 
 void Trace::on_nameedit_changed(const QString &name)

--- a/pv/views/trace/trace.hpp
+++ b/pv/views/trace/trace.hpp
@@ -197,6 +197,8 @@ protected Q_SLOTS:
 
 	void on_popup_closed();
 
+	virtual void on_samples_cleared();
+
 private Q_SLOTS:
 	void on_nameedit_changed(const QString &name);
 


### PR DESCRIPTION
This PR fixes the initialization and resetting of `signal_min_` and `signal_max_` values in `AnalogSignal`.

Those values are used to determine the SI prefix when a value is displayed. Without this fix,  `signal_min_ ` and/or `signal_max_` sometimes start with high values, leading to signal readings like e.g. `0.000 GV`, or with `NaN`, leading to readings like e.g. `7384926150847261938450274 yV`.

The PR also resets `signal_min_` and `signal_max_` whenever a new acquisition is started.

Because autoranging also sets `signal_min_` and `signal_max_`, the issue only becomes noticable when autoranging is disabled.
